### PR TITLE
Use features instead of build.rs to select llvm_x_or_greater

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,23 @@ itertools = "0.9"
 [features]
 # Select the LLVM version to be compatible with.
 # You _must_ enable exactly one of the following features.
-llvm-8 = ["llvm-sys-80"]
-llvm-9 = ["llvm-sys-90"]
-llvm-10 = ["llvm-sys-100"]
-llvm-11 = ["llvm-sys-110"]
+llvm-8 = ["llvm-sys-80", "llvm-8-or-lower", "llvm-8-or-greater"]
+llvm-9 = ["llvm-sys-90", "llvm-9-or-lower", "llvm-9-or-greater"]
+llvm-10 = ["llvm-sys-100", "llvm-10-or-lower", "llvm-10-or-greater"]
+llvm-11 = ["llvm-sys-110", "llvm-11-or-lower", "llvm-11-or-greater"]
+
+# For convenience, these automatically-enabled features allow us to avoid
+# checking complex combinations of features all the time. they are not meant to
+# be manually enabled, use the above llvm-x features instead
+llvm-8-or-greater = []
+llvm-9-or-greater = ["llvm-8-or-greater"]
+llvm-10-or-greater = ["llvm-9-or-greater"]
+llvm-11-or-greater = ["llvm-10-or-greater"]
+
+llvm-8-or-lower = ["llvm-9-or-lower"]
+llvm-9-or-lower = ["llvm-10-or-lower"]
+llvm-10-or-lower = ["llvm-11-or-lower"]
+llvm-11-or-lower = []
 
 # We'd like to have a "strict-versioning" feature which enables the
 # corresponding feature in llvm-sys. "strict-versioning" requires an exact

--- a/build.rs
+++ b/build.rs
@@ -12,30 +12,9 @@ fn main() {
     if cfg!(feature = "llvm-11") {
         versions.push(11);
     }
-    let selected_version = match versions.len() {
+    match versions.len() {
         0 => panic!("llvm-ir: Please select an LLVM version using a Cargo feature."),
-        1 => versions[0],
+        1 => {},
         _ => panic!("llvm-ir: Multiple LLVM versions selected. Please activate only one LLVM version feature. (Got {:?})", versions),
     };
-
-    // For convenience we set a number of configuration options to avoid
-    // checking complex combinations of features all the time.
-    if selected_version >= 9 {
-        println!("cargo:rustc-cfg=LLVM_VERSION_9_OR_GREATER");
-    }
-    if selected_version >= 10 {
-        println!("cargo:rustc-cfg=LLVM_VERSION_10_OR_GREATER");
-    }
-    if selected_version >= 11 {
-        println!("cargo:rustc-cfg=LLVM_VERSION_11_OR_GREATER");
-    }
-    if selected_version <= 10 {
-        println!("cargo:rustc-cfg=LLVM_VERSION_10_OR_LOWER");
-    }
-    if selected_version <= 9 {
-        println!("cargo:rustc-cfg=LLVM_VERSION_9_OR_LOWER");
-    }
-    if selected_version <= 8 {
-        println!("cargo:rustc-cfg=LLVM_VERSION_8_OR_LOWER");
-    }
 }

--- a/src/basicblock.rs
+++ b/src/basicblock.rs
@@ -20,7 +20,7 @@ impl BasicBlock {
             name,
             instrs: vec![],
             term: Terminator::Unreachable(Unreachable {
-                #[cfg(LLVM_VERSION_9_OR_GREATER)]
+                #[cfg(feature="llvm-9-or-greater")]
                 debugloc: None,
             }),
         }
@@ -113,7 +113,7 @@ fn term_needs_name(term: LLVMValueRef) -> bool {
     match unsafe { LLVMGetInstructionOpcode(term) } {
         LLVMOpcode::LLVMInvoke => true,
         LLVMOpcode::LLVMCatchSwitch => true,
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         LLVMOpcode::LLVMCallBr => true,
         _ => false, // all other terminators have no result (destination) and thus don't need names
     }

--- a/src/from_llvm.rs
+++ b/src/from_llvm.rs
@@ -45,7 +45,7 @@ macro_rules! wrap_with_len {
     };
 }
 
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 macro_rules! wrap_with_len_maybe_null {
     ($llvmFunc:ident, $argty:ty, $wrapperFunc:ident) => {
         pub unsafe fn $wrapperFunc(arg: $argty) -> Option<String> {
@@ -75,9 +75,9 @@ wrap!(LLVMPrintValueToString, LLVMValueRef, print_to_string);
 // wrap!(LLVMPrintTypeToString, LLVMTypeRef, print_type_to_string);
 wrap_with_len!(LLVMGetStringAttributeKind, LLVMAttributeRef, get_string_attribute_kind);
 wrap_with_len!(LLVMGetStringAttributeValue, LLVMAttributeRef, get_string_attribute_value);
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 wrap_with_len_maybe_null!(LLVMGetDebugLocFilename, LLVMValueRef, get_debugloc_filename);
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 wrap_with_len_maybe_null!(LLVMGetDebugLocDirectory, LLVMValueRef, get_debugloc_directory);
 
 // Panics if the LLVMValueRef is not a basic block

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,4 +1,4 @@
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 use crate::debugloc::{DebugLoc, HasDebugLoc};
 use crate::module::{Comdat, DLLStorageClass, Linkage, Visibility};
 use crate::types::{TypeRef, Typed, Types};
@@ -26,7 +26,7 @@ pub struct Function {
     // pub prefix: Option<ConstantRef>,  // appears to not be exposed in the LLVM C API, only the C++ API
     /// Personalities are used for exception handling. See [LLVM 11 docs on Personality Function](https://releases.llvm.org/11.0.0/docs/LangRef.html#personalityfn)
     pub personality_function: Option<ConstantRef>,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: Vec<(String, MetadataRef<MetadataNode>)>,
 }
@@ -41,7 +41,7 @@ impl Typed for Function {
     }
 }
 
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 impl HasDebugLoc for Function {
     fn get_debug_loc(&self) -> &Option<DebugLoc> {
         &self.debugloc
@@ -78,7 +78,7 @@ impl Function {
             alignment: 4,
             garbage_collector_name: None,
             personality_function: None,
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: None,
         }
     }
@@ -169,23 +169,23 @@ pub enum FunctionAttribute {
     NoBuiltin,
     NoCFCheck,
     NoDuplicate,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     NoFree,
     NoImplicitFloat,
     NoInline,
-    #[cfg(LLVM_VERSION_11_OR_GREATER)]
+    #[cfg(feature="llvm-11-or-greater")]
     NoMerge,
     NonLazyBind,
     NoRedZone,
     NoReturn,
     NoRecurse,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     WillReturn,
     ReturnsTwice,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     NoSync,
     NoUnwind,
-    #[cfg(LLVM_VERSION_11_OR_GREATER)]
+    #[cfg(feature="llvm-11-or-greater")]
     NullPointerIsValid,
     OptForFuzzing,
     OptNone,
@@ -199,7 +199,7 @@ pub enum FunctionAttribute {
     SanitizeMemory,
     SanitizeThread,
     SanitizeHWAddress,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     SanitizeMemTag,
     ShadowCallStack,
     SpeculativeLoadHardening,
@@ -221,14 +221,14 @@ pub enum ParameterAttribute {
     SignExt,
     InReg,
     ByVal,
-    #[cfg(LLVM_VERSION_11_OR_GREATER)]
+    #[cfg(feature="llvm-11-or-greater")]
     Preallocated,
     InAlloca,
     SRet,
     Alignment(u64),
     NoAlias,
     NoCapture,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     NoFree,
     Nest,
     Returned,
@@ -238,7 +238,7 @@ pub enum ParameterAttribute {
     SwiftSelf,
     SwiftError,
     ImmArg,
-    #[cfg(LLVM_VERSION_11_OR_GREATER)]
+    #[cfg(feature="llvm-11-or-greater")]
     NoUndef,
     StringAttribute { kind: String, value: String }, // for no value, use ""
     UnknownAttribute, // this is used if we get a value not in the above list
@@ -418,7 +418,7 @@ impl Function {
                     None
                 }
             },
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_no_col(func),
             // metadata: unimplemented!("Function.metadata"),
         }
@@ -501,23 +501,23 @@ impl AttributesData {
             "nobuiltin",
             "nocf_check",
             "noduplicate",
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             "nofree",
             "noimplicitfloat",
             "noinline",
-            #[cfg(LLVM_VERSION_11_OR_GREATER)]
+            #[cfg(feature="llvm-11-or-greater")]
             "nomerge",
             "nonlazybind",
             "noredzone",
             "noreturn",
             "norecurse",
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             "willreturn",
             "returns_twice",
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             "nosync",
             "nounwind",
-            #[cfg(LLVM_VERSION_11_OR_GREATER)]
+            #[cfg(feature="llvm-11-or-greater")]
             "null_pointer_is_valid",
             "optforfuzzing",
             "optnone",
@@ -531,7 +531,7 @@ impl AttributesData {
             "sanitize_memory",
             "sanitize_thread",
             "sanitize_hwaddress",
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             "sanitize_memtag",
             "shadowcallstack",
             "speculative_load_hardening",
@@ -555,14 +555,14 @@ impl AttributesData {
             "signext",
             "inreg",
             "byval",
-            #[cfg(LLVM_VERSION_11_OR_GREATER)]
+            #[cfg(feature="llvm-11-or-greater")]
             "preallocated",
             "inalloca",
             "sret",
             "align",
             "noalias",
             "nocapture",
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             "nofree",
             "nest",
             "returned",
@@ -571,9 +571,9 @@ impl AttributesData {
             "dereferenceable_or_null",
             "swiftself",
             "swifterror",
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             "immarg",
-            #[cfg(LLVM_VERSION_11_OR_GREATER)]
+            #[cfg(feature="llvm-11-or-greater")]
             "noundef",
         ]
         .iter()
@@ -635,23 +635,23 @@ impl FunctionAttribute {
                 Some("nobuiltin") => Self::NoBuiltin,
                 Some("nocf_check") => Self::NoCFCheck,
                 Some("noduplicate") => Self::NoDuplicate,
-                #[cfg(LLVM_VERSION_9_OR_GREATER)]
+                #[cfg(feature="llvm-9-or-greater")]
                 Some("nofree") => Self::NoFree,
                 Some("noimplicitfloat") => Self::NoImplicitFloat,
                 Some("noinline") => Self::NoInline,
-                #[cfg(LLVM_VERSION_11_OR_GREATER)]
+                #[cfg(feature="llvm-11-or-greater")]
                 Some("nomerge") => Self::NoMerge,
                 Some("nonlazybind") => Self::NonLazyBind,
                 Some("noredzone") => Self::NoRedZone,
                 Some("noreturn") => Self::NoReturn,
                 Some("norecurse") => Self::NoRecurse,
-                #[cfg(LLVM_VERSION_9_OR_GREATER)]
+                #[cfg(feature="llvm-9-or-greater")]
                 Some("willreturn") => Self::WillReturn,
                 Some("returns_twice") => Self::ReturnsTwice,
-                #[cfg(LLVM_VERSION_9_OR_GREATER)]
+                #[cfg(feature="llvm-9-or-greater")]
                 Some("nosync") => Self::NoSync,
                 Some("nounwind") => Self::NoUnwind,
-                #[cfg(LLVM_VERSION_11_OR_GREATER)]
+                #[cfg(feature="llvm-11-or-greater")]
                 Some("null_pointer_is_valid") => Self::NullPointerIsValid,
                 Some("optforfuzzing") => Self::OptForFuzzing,
                 Some("optnone") => Self::OptNone,
@@ -665,7 +665,7 @@ impl FunctionAttribute {
                 Some("sanitize_memory") => Self::SanitizeMemory,
                 Some("sanitize_thread") => Self::SanitizeThread,
                 Some("sanitize_hwaddress") => Self::SanitizeHWAddress,
-                #[cfg(LLVM_VERSION_9_OR_GREATER)]
+                #[cfg(feature="llvm-9-or-greater")]
                 Some("sanitize_memtag") => Self::SanitizeMemTag,
                 Some("shadowcallstack") => Self::ShadowCallStack,
                 Some("speculative_load_hardening") => Self::SpeculativeLoadHardening,
@@ -699,14 +699,14 @@ impl ParameterAttribute {
                 Some("signext") => Self::SignExt,
                 Some("inreg") => Self::InReg,
                 Some("byval") => Self::ByVal,
-                #[cfg(LLVM_VERSION_11_OR_GREATER)]
+                #[cfg(feature="llvm-11-or-greater")]
                 Some("preallocated") => Self::Preallocated,
                 Some("inalloca") => Self::InAlloca,
                 Some("sret") => Self::SRet,
                 Some("align") => Self::Alignment(unsafe { LLVMGetEnumAttributeValue(a) }),
                 Some("noalias") => Self::NoAlias,
                 Some("nocapture") => Self::NoCapture,
-                #[cfg(LLVM_VERSION_9_OR_GREATER)]
+                #[cfg(feature="llvm-9-or-greater")]
                 Some("nofree") => Self::NoFree,
                 Some("nest") => Self::Nest,
                 Some("returned") => Self::Returned,
@@ -716,7 +716,7 @@ impl ParameterAttribute {
                 Some("swiftself") => Self::SwiftSelf,
                 Some("swifterror") => Self::SwiftError,
                 Some("immarg") => Self::ImmArg,
-                #[cfg(LLVM_VERSION_11_OR_GREATER)]
+                #[cfg(feature="llvm-11-or-greater")]
                 Some("noundef") => Self::NoUndef,
                 Some(s) => panic!("Unhandled value from lookup_param_attr: {:?}", s),
                 None => Self::UnknownAttribute,

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1,5 +1,5 @@
 use crate::constant::ConstantRef;
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 use crate::debugloc::{DebugLoc, HasDebugLoc};
 use crate::function::{CallingConvention, FunctionAttribute, ParameterAttribute};
 use crate::name::Name;
@@ -76,7 +76,7 @@ pub enum Instruction {
     FCmp(FCmp),
     Phi(Phi),
     Select(Select),
-    #[cfg(LLVM_VERSION_10_OR_GREATER)]
+    #[cfg(feature="llvm-10-or-greater")]
     Freeze(Freeze),
     Call(Call),
     VAArg(VAArg),
@@ -137,7 +137,7 @@ impl Typed for Instruction {
             Instruction::FCmp(i) => types.type_of(i),
             Instruction::Phi(i) => types.type_of(i),
             Instruction::Select(i) => types.type_of(i),
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             Instruction::Freeze(i) => types.type_of(i),
             Instruction::Call(i) => types.type_of(i),
             Instruction::VAArg(i) => types.type_of(i),
@@ -148,7 +148,7 @@ impl Typed for Instruction {
     }
 }
 
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 impl HasDebugLoc for Instruction {
     fn get_debug_loc(&self) -> &Option<DebugLoc> {
         match self {
@@ -200,7 +200,7 @@ impl HasDebugLoc for Instruction {
             Instruction::FCmp(i) => i.get_debug_loc(),
             Instruction::Phi(i) => i.get_debug_loc(),
             Instruction::Select(i) => i.get_debug_loc(),
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             Instruction::Freeze(i) => i.get_debug_loc(),
             Instruction::Call(i) => i.get_debug_loc(),
             Instruction::VAArg(i) => i.get_debug_loc(),
@@ -264,7 +264,7 @@ impl Instruction {
             Instruction::FCmp(i) => Some(&i.dest),
             Instruction::Phi(i) => Some(&i.dest),
             Instruction::Select(i) => Some(&i.dest),
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             Instruction::Freeze(i) => Some(&i.dest),
             Instruction::Call(i) => i.dest.as_ref(),
             Instruction::VAArg(i) => Some(&i.dest),
@@ -325,7 +325,7 @@ impl Instruction {
             Instruction::FCmp(_) => false,
             Instruction::Phi(_) => false,
             Instruction::Select(_) => false,
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             Instruction::Freeze(_) => false,
             Instruction::Call(_) => false,
             Instruction::VAArg(_) => false,
@@ -392,7 +392,7 @@ impl HasMetadata for Instruction {
             Instruction::FCmp(i) => &i.metadata,
             Instruction::Phi(i) => &i.metadata,
             Instruction::Select(i) => &i.metadata,
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             Instruction::Freeze(i) => &i.metadata,
             Instruction::Call(i) => &i.metadata,
             Instruction::VAArg(i) => &i.metadata,
@@ -459,7 +459,7 @@ impl Instruction {
             Instruction::FPToSI(_) => true,
             Instruction::FPToUI(_) => true,
             Instruction::FPTrunc(_) => true,
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             Instruction::Freeze(_) => true,
             Instruction::IntToPtr(_) => true,
             Instruction::PtrToInt(_) => true,
@@ -524,7 +524,7 @@ impl Display for Instruction {
             Instruction::FCmp(i) => write!(f, "{}", i),
             Instruction::Phi(i) => write!(f, "{}", i),
             Instruction::Select(i) => write!(f, "{}", i),
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             Instruction::Freeze(i) => write!(f, "{}", i),
             Instruction::Call(i) => write!(f, "{}", i),
             Instruction::VAArg(i) => write!(f, "{}", i),
@@ -553,7 +553,7 @@ macro_rules! impl_inst {
             }
         }
 
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         impl HasDebugLoc for $inst {
             fn get_debug_loc(&self) -> &Option<DebugLoc> {
                 &self.debugloc
@@ -632,7 +632,7 @@ macro_rules! impl_binop {
                 write!(f, "{} = {} {}, {}",
                     &self.dest, $dispname, &self.operand0, &self.operand1,
                 )?;
-                #[cfg(LLVM_VERSION_9_OR_GREATER)]
+                #[cfg(feature="llvm-9-or-greater")]
                 if self.debugloc.is_some() {
                     write!(f, " (with debugloc)")?;
                 }
@@ -656,7 +656,7 @@ macro_rules! unop_same_type {
         impl Display for $inst {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 write!(f, "{} = {} {}", &self.dest, $dispname, &self.operand)?;
-                #[cfg(LLVM_VERSION_9_OR_GREATER)]
+                #[cfg(feature="llvm-9-or-greater")]
                 if self.debugloc.is_some() {
                     write!(f, " (with debugloc)")?;
                 }
@@ -677,7 +677,7 @@ macro_rules! unop_explicitly_typed {
                 write!(f, "{} = {} {} to {}",
                     &self.dest, $dispname, &self.operand, &self.to_type,
                 )?;
-                #[cfg(LLVM_VERSION_9_OR_GREATER)]
+                #[cfg(feature="llvm-9-or-greater")]
                 if self.debugloc.is_some() {
                     write!(f, " (with debugloc)")?;
                 }
@@ -745,7 +745,7 @@ pub struct Add {
     pub dest: Name,
     // pub nsw: bool,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
     // pub nuw: bool,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -762,7 +762,7 @@ pub struct Sub {
     pub dest: Name,
     // pub nsw: bool,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
     // pub nuw: bool,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -779,7 +779,7 @@ pub struct Mul {
     pub dest: Name,
     // pub nsw: bool,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
     // pub nuw: bool,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -795,7 +795,7 @@ pub struct UDiv {
     pub operand1: Operand,
     pub dest: Name,
     // pub exact: bool,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -811,7 +811,7 @@ pub struct SDiv {
     pub operand1: Operand,
     pub dest: Name,
     // pub exact: bool,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -826,7 +826,7 @@ pub struct URem {
     pub operand0: Operand,
     pub operand1: Operand,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -841,7 +841,7 @@ pub struct SRem {
     pub operand0: Operand,
     pub operand1: Operand,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -856,7 +856,7 @@ pub struct And {
     pub operand0: Operand,
     pub operand1: Operand,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -871,7 +871,7 @@ pub struct Or {
     pub operand0: Operand,
     pub operand1: Operand,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -886,7 +886,7 @@ pub struct Xor {
     pub operand0: Operand,
     pub operand1: Operand,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -903,7 +903,7 @@ pub struct Shl {
     pub dest: Name,
     // pub nsw: bool,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
     // pub nuw: bool,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -919,7 +919,7 @@ pub struct LShr {
     pub operand1: Operand,
     pub dest: Name,
     // pub exact: bool,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -935,7 +935,7 @@ pub struct AShr {
     pub operand1: Operand,
     pub dest: Name,
     // pub exact: bool,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -951,7 +951,7 @@ pub struct FAdd {
     pub operand1: Operand,
     pub dest: Name,
     // pub fast_math_flags: FastMathFlags,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -967,7 +967,7 @@ pub struct FSub {
     pub operand1: Operand,
     pub dest: Name,
     // pub fast_math_flags: FastMathFlags,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -983,7 +983,7 @@ pub struct FMul {
     pub operand1: Operand,
     pub dest: Name,
     // pub fast_math_flags: FastMathFlags,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -999,7 +999,7 @@ pub struct FDiv {
     pub operand1: Operand,
     pub dest: Name,
     // pub fast_math_flags: FastMathFlags,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1015,7 +1015,7 @@ pub struct FRem {
     pub operand1: Operand,
     pub dest: Name,
     // pub fast_math_flags: FastMathFlags,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1030,7 +1030,7 @@ pub struct FNeg {
     pub operand: Operand,
     pub dest: Name,
     // pub fast_math_flags: FastMathFlags,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1045,7 +1045,7 @@ pub struct ExtractElement {
     pub vector: Operand,
     pub index: Operand,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1070,7 +1070,7 @@ impl Display for ExtractElement {
         write!(f, "{} = extractelement {}, {}",
             &self.dest, &self.vector, &self.index,
         )?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1086,7 +1086,7 @@ pub struct InsertElement {
     pub element: Operand,
     pub index: Operand,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1105,7 +1105,7 @@ impl Display for InsertElement {
         write!(f, "{} = insertelement {}, {}, {}",
             &self.dest, &self.vector, &self.element, &self.index,
         )?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1121,7 +1121,7 @@ pub struct ShuffleVector {
     pub operand1: Operand,
     pub dest: Name,
     pub mask: ConstantRef,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1135,11 +1135,11 @@ impl Typed for ShuffleVector {
         debug_assert_eq!(ty, types.type_of(&self.operand1));
         match ty.as_ref() {
             Type::VectorType { element_type, .. } => match types.type_of(&self.mask).as_ref() {
-                #[cfg(LLVM_VERSION_11_OR_GREATER)]
+                #[cfg(feature="llvm-11-or-greater")]
                 Type::VectorType { num_elements, scalable, .. } => {
                     types.vector_of(element_type.clone(), *num_elements, *scalable)
                 },
-                #[cfg(LLVM_VERSION_10_OR_LOWER)]
+                #[cfg(feature="llvm-10-or-lower")]
                 Type::VectorType { num_elements, .. } => {
                     types.vector_of(element_type.clone(), *num_elements)
                 },
@@ -1161,7 +1161,7 @@ impl Display for ShuffleVector {
         write!(f, "{} = shufflevector {}, {}, {}",
             &self.dest, &self.operand0, &self.operand1, &self.mask,
         )?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1176,7 +1176,7 @@ pub struct ExtractValue {
     pub aggregate: Operand,
     pub indices: Vec<u32>,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1220,7 +1220,7 @@ impl Display for ExtractValue {
         for idx in &self.indices[1 ..] {
             write!(f, ", {}", idx)?;
         }
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1236,7 +1236,7 @@ pub struct InsertValue {
     pub element: Operand,
     pub indices: Vec<u32>,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1261,7 +1261,7 @@ impl Display for InsertValue {
         for idx in &self.indices[1 ..] {
             write!(f, ", {}", idx)?;
         }
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1277,7 +1277,7 @@ pub struct Alloca {
     pub num_elements: Operand, // llvm-hs-pure has Option<Operand>
     pub dest: Name,
     pub alignment: u32,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1302,7 +1302,7 @@ impl Display for Alloca {
             write!(f, ", {}", &self.num_elements)?;
         }
         write!(f, ", align {}", &self.alignment)?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1319,7 +1319,7 @@ pub struct Load {
     pub volatile: bool,
     pub atomicity: Option<Atomicity>,
     pub alignment: u32,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1353,7 +1353,7 @@ impl Display for Load {
             write!(f, " {}", a)?;
         }
         write!(f, ", align {}", &self.alignment)?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1370,7 +1370,7 @@ pub struct Store {
     pub volatile: bool,
     pub atomicity: Option<Atomicity>,
     pub alignment: u32,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1392,7 +1392,7 @@ impl Display for Store {
             write!(f, " {}", a)?;
         }
         write!(f, ", align {}", &self.alignment)?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1405,7 +1405,7 @@ impl Display for Store {
 #[derive(PartialEq, Clone, Debug)]
 pub struct Fence {
     pub atomicity: Atomicity,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1416,7 +1416,7 @@ void_typed!(Fence);
 impl Display for Fence {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "fence {}", &self.atomicity)?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1437,9 +1437,9 @@ pub struct CmpXchg {
     pub atomicity: Atomicity,
     /// This is the "failure" `MemoryOrdering`
     pub failure_memory_ordering: MemoryOrdering,
-    #[cfg(LLVM_VERSION_10_OR_GREATER)]
+    #[cfg(feature="llvm-10-or-greater")]
     pub weak: bool,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1458,7 +1458,7 @@ impl Typed for CmpXchg {
 impl Display for CmpXchg {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} = cmpxchg ", &self.dest)?;
-        #[cfg(LLVM_VERSION_10_OR_GREATER)]
+        #[cfg(feature="llvm-10-or-greater")]
         if self.weak {
             write!(f, "weak ")?;
         }
@@ -1472,7 +1472,7 @@ impl Display for CmpXchg {
             &self.atomicity,
             &self.failure_memory_ordering,
         )?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1484,14 +1484,14 @@ impl Display for CmpXchg {
 /// See [LLVM 11 docs on the 'atomicrmw' instruction](https://releases.llvm.org/11.0.0/docs/LangRef.html#atomicrmw-instruction)
 #[derive(PartialEq, Clone, Debug)]
 pub struct AtomicRMW {
-    #[cfg(LLVM_VERSION_10_OR_GREATER)] // the binop-getter was added to the LLVM C API in LLVM 10
+    #[cfg(feature="llvm-10-or-greater")] // the binop-getter was added to the LLVM C API in LLVM 10
     pub operation: RMWBinOp,
     pub address: Operand,
     pub value: Operand,
     pub dest: Name,
     pub volatile: bool,
     pub atomicity: Atomicity,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1517,10 +1517,10 @@ impl Display for AtomicRMW {
         if self.volatile {
             write!(f, "volatile ")?;
         }
-        #[cfg(LLVM_VERSION_10_OR_GREATER)]
+        #[cfg(feature="llvm-10-or-greater")]
         write!(f, "{} ", &self.operation)?;
         write!(f, "{}, {} {}", &self.address, &self.value, &self.atomicity)?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1537,7 +1537,7 @@ pub struct GetElementPtr {
     pub indices: Vec<Operand>,
     pub dest: Name,
     pub in_bounds: bool,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1604,7 +1604,7 @@ impl Display for GetElementPtr {
         for idx in &self.indices {
             write!(f, ", {}", idx)?;
         }
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1619,7 +1619,7 @@ pub struct Trunc {
     pub operand: Operand,
     pub to_type: TypeRef,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1634,7 +1634,7 @@ pub struct ZExt {
     pub operand: Operand,
     pub to_type: TypeRef,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1649,7 +1649,7 @@ pub struct SExt {
     pub operand: Operand,
     pub to_type: TypeRef,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1664,7 +1664,7 @@ pub struct FPTrunc {
     pub operand: Operand,
     pub to_type: TypeRef,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1679,7 +1679,7 @@ pub struct FPExt {
     pub operand: Operand,
     pub to_type: TypeRef,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1694,7 +1694,7 @@ pub struct FPToUI {
     pub operand: Operand,
     pub to_type: TypeRef,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1709,7 +1709,7 @@ pub struct FPToSI {
     pub operand: Operand,
     pub to_type: TypeRef,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1724,7 +1724,7 @@ pub struct UIToFP {
     pub operand: Operand,
     pub to_type: TypeRef,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1739,7 +1739,7 @@ pub struct SIToFP {
     pub operand: Operand,
     pub to_type: TypeRef,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1754,7 +1754,7 @@ pub struct PtrToInt {
     pub operand: Operand,
     pub to_type: TypeRef,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1769,7 +1769,7 @@ pub struct IntToPtr {
     pub operand: Operand,
     pub to_type: TypeRef,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1784,7 +1784,7 @@ pub struct BitCast {
     pub operand: Operand,
     pub to_type: TypeRef,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1799,7 +1799,7 @@ pub struct AddrSpaceCast {
     pub operand: Operand,
     pub to_type: TypeRef,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1815,7 +1815,7 @@ pub struct ICmp {
     pub operand0: Operand,
     pub operand1: Operand,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1828,11 +1828,11 @@ impl Typed for ICmp {
         let ty = types.type_of(&self.operand0);
         debug_assert_eq!(ty, types.type_of(&self.operand1));
         match ty.as_ref() {
-            #[cfg(LLVM_VERSION_11_OR_GREATER)]
+            #[cfg(feature="llvm-11-or-greater")]
             Type::VectorType { num_elements, scalable, .. } => {
                 types.vector_of(types.bool(), *num_elements, *scalable)
             },
-            #[cfg(LLVM_VERSION_10_OR_LOWER)]
+            #[cfg(feature="llvm-10-or-lower")]
             Type::VectorType { num_elements, .. } => {
                 types.vector_of(types.bool(), *num_elements)
             },
@@ -1849,7 +1849,7 @@ impl Display for ICmp {
             &self.operand0,
             &self.operand1,
         )?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1865,7 +1865,7 @@ pub struct FCmp {
     pub operand0: Operand,
     pub operand1: Operand,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1878,11 +1878,11 @@ impl Typed for FCmp {
         let ty = types.type_of(&self.operand0);
         debug_assert_eq!(ty, types.type_of(&self.operand1));
         match ty.as_ref() {
-            #[cfg(LLVM_VERSION_11_OR_GREATER)]
+            #[cfg(feature="llvm-11-or-greater")]
             Type::VectorType { num_elements, scalable, .. } => {
                 types.vector_of(types.bool(), *num_elements, *scalable)
             },
-            #[cfg(LLVM_VERSION_10_OR_LOWER)]
+            #[cfg(feature="llvm-10-or-lower")]
             Type::VectorType { num_elements, .. } => {
                 types.vector_of(types.bool(), *num_elements)
             },
@@ -1896,7 +1896,7 @@ impl Display for FCmp {
         write!(f, "{} = fcmp {} {}, {}",
             &self.dest, &self.predicate, &self.operand0, &self.operand1,
         )?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1910,7 +1910,7 @@ pub struct Phi {
     pub incoming_values: Vec<(Operand, Name)>,
     pub dest: Name,
     pub to_type: TypeRef,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1931,7 +1931,7 @@ impl Display for Phi {
         for (val, label) in &self.incoming_values[1 ..] {
             write!(f, ", [ {}, {} ]", val, label)?;
         }
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1947,7 +1947,7 @@ pub struct Select {
     pub true_value: Operand,
     pub false_value: Operand,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -1968,7 +1968,7 @@ impl Display for Select {
         write!(f, "{} = select {}, {}, {}",
             &self.dest, &self.condition, &self.true_value, &self.false_value,
         )?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1978,19 +1978,19 @@ impl Display for Select {
 
 /// Stop the propagation of `undef` or `poison` values.
 /// See [LLVM 11 docs on the 'freeze' instruction](https://releases.llvm.org/11.0.0/docs/LangRef.html#freeze-instruction)
-#[cfg(LLVM_VERSION_10_OR_GREATER)]
+#[cfg(feature="llvm-10-or-greater")]
 #[derive(PartialEq, Clone, Debug)]
 pub struct Freeze {
     pub operand: Operand,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
 
-#[cfg(LLVM_VERSION_10_OR_GREATER)]
+#[cfg(feature="llvm-10-or-greater")]
 impl_inst!(Freeze, Freeze);
-#[cfg(LLVM_VERSION_10_OR_GREATER)]
+#[cfg(feature="llvm-10-or-greater")]
 unop_same_type!(Freeze, "freeze");
 
 /// Function call.
@@ -2004,7 +2004,7 @@ pub struct Call {
     pub function_attributes: Vec<FunctionAttribute>, // llvm-hs has the equivalent of Vec<Either<GroupID, FunctionAttribute>>, but I'm not sure how the GroupID option comes up
     pub is_tail_call: bool, // llvm-hs has the more sophisticated structure Option<TailCallKind>, but the LLVM C API just gives us true/false
     pub calling_convention: CallingConvention,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -2047,7 +2047,7 @@ impl Display for Call {
             }
         }
         write!(f, ")")?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -2062,7 +2062,7 @@ pub struct VAArg {
     pub arg_list: Operand,
     pub cur_type: TypeRef,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -2081,7 +2081,7 @@ impl Display for VAArg {
         write!(f, "{} = va_arg {}, {}",
             &self.dest, &self.arg_list, &self.cur_type,
         )?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -2097,7 +2097,7 @@ pub struct LandingPad {
     pub clauses: Vec<LandingPadClause>,
     pub dest: Name,
     pub cleanup: bool,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -2117,7 +2117,7 @@ impl Display for LandingPad {
         if self.cleanup {
             write!(f, " cleanup")?;
         }
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -2132,7 +2132,7 @@ pub struct CatchPad {
     pub catch_switch: Operand,
     pub args: Vec<Operand>,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -2159,7 +2159,7 @@ impl Display for CatchPad {
             }
         }
         write!(f, "]")?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -2174,7 +2174,7 @@ pub struct CleanupPad {
     pub parent_pad: Operand,
     pub args: Vec<Operand>,
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -2201,7 +2201,7 @@ impl Display for CleanupPad {
             }
         }
         write!(f, "]")?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -2331,9 +2331,9 @@ pub enum RMWBinOp {
     Min,
     UMax,
     UMin,
-    #[cfg(LLVM_VERSION_10_OR_GREATER)]
+    #[cfg(feature="llvm-10-or-greater")]
     FAdd,
-    #[cfg(LLVM_VERSION_10_OR_GREATER)]
+    #[cfg(feature="llvm-10-or-greater")]
     FSub,
 }
 
@@ -2351,9 +2351,9 @@ impl Display for RMWBinOp {
             Self::Min => write!(f, "min"),
             Self::UMax => write!(f, "umax"),
             Self::UMin => write!(f, "umin"),
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             Self::FAdd => write!(f, "fadd"),
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             Self::FSub => write!(f, "fsub"),
         }
     }
@@ -2387,11 +2387,11 @@ use crate::llvm_sys::*;
 use crate::module::ModuleContext;
 use crate::types::TypesBuilder;
 use llvm_sys::LLVMAtomicOrdering;
-#[cfg(LLVM_VERSION_10_OR_GREATER)]
+#[cfg(feature="llvm-10-or-greater")]
 use llvm_sys::LLVMAtomicRMWBinOp;
 use llvm_sys::LLVMOpcode;
 use llvm_sys::LLVMTypeKind::LLVMVoidTypeKind;
-#[cfg(LLVM_VERSION_11_OR_GREATER)]
+#[cfg(feature="llvm-11-or-greater")]
 use std::convert::TryInto;
 
 impl Instruction {
@@ -2490,7 +2490,7 @@ impl Instruction {
             LLVMOpcode::LLVMSelect => {
                 Instruction::Select(Select::from_llvm_ref(inst, ctx, func_ctx))
             },
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             LLVMOpcode::LLVMFreeze => {
                 Instruction::Freeze(Freeze::from_llvm_ref(inst, ctx, func_ctx))
             },
@@ -2529,7 +2529,7 @@ macro_rules! unop_from_llvm {
                         func_ctx,
                     ),
                     dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
-                    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+                    #[cfg(feature="llvm-9-or-greater")]
                     debugloc: DebugLoc::from_llvm_with_col(inst),
                     // metadata: InstructionMetadata::from_llvm_inst(inst),
                 }
@@ -2559,7 +2559,7 @@ macro_rules! binop_from_llvm {
                         func_ctx,
                     ),
                     dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
-                    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+                    #[cfg(feature="llvm-9-or-greater")]
                     debugloc: DebugLoc::from_llvm_with_col(inst),
                     // metadata: InstructionMetadata::from_llvm_inst(inst),
                 }
@@ -2587,7 +2587,7 @@ binop_from_llvm!(FMul);
 binop_from_llvm!(FDiv);
 binop_from_llvm!(FRem);
 unop_from_llvm!(FNeg);
-#[cfg(LLVM_VERSION_10_OR_GREATER)]
+#[cfg(feature="llvm-10-or-greater")]
 unop_from_llvm!(Freeze);
 
 impl ExtractElement {
@@ -2601,7 +2601,7 @@ impl ExtractElement {
             vector: Operand::from_llvm_ref(unsafe { LLVMGetOperand(inst, 0) }, ctx, func_ctx),
             index: Operand::from_llvm_ref(unsafe { LLVMGetOperand(inst, 1) }, ctx, func_ctx),
             dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -2620,7 +2620,7 @@ impl InsertElement {
             element: Operand::from_llvm_ref(unsafe { LLVMGetOperand(inst, 1) }, ctx, func_ctx),
             index: Operand::from_llvm_ref(unsafe { LLVMGetOperand(inst, 2) }, ctx, func_ctx),
             dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -2633,16 +2633,16 @@ impl ShuffleVector {
         ctx: &mut ModuleContext,
         func_ctx: &mut FunctionContext,
     ) -> Self {
-        #[cfg(LLVM_VERSION_10_OR_LOWER)]
+        #[cfg(feature="llvm-10-or-lower")]
         assert_eq!(unsafe { LLVMGetNumOperands(inst) }, 3);
-        #[cfg(LLVM_VERSION_11_OR_GREATER)]
+        #[cfg(feature="llvm-11-or-greater")]
         assert_eq!(unsafe { LLVMGetNumOperands(inst) }, 2);
         Self {
             operand0: Operand::from_llvm_ref(unsafe { LLVMGetOperand(inst, 0) }, ctx, func_ctx),
             operand1: Operand::from_llvm_ref(unsafe { LLVMGetOperand(inst, 1) }, ctx, func_ctx),
-            #[cfg(LLVM_VERSION_10_OR_LOWER)]
+            #[cfg(feature="llvm-10-or-lower")]
             mask: Constant::from_llvm_ref(unsafe { LLVMGetOperand(inst, 2) }, ctx),
-            #[cfg(LLVM_VERSION_11_OR_GREATER)]
+            #[cfg(feature="llvm-11-or-greater")]
             mask: {
                 let ret_ty = ctx.types.type_from_llvm_ref(unsafe { LLVMTypeOf(inst) });
                 match ret_ty.as_ref() {
@@ -2671,7 +2671,7 @@ impl ShuffleVector {
                 }
             },
             dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -2693,7 +2693,7 @@ impl ExtractValue {
                 std::slice::from_raw_parts(ptr, num_indices as usize).to_vec()
             },
             dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -2716,7 +2716,7 @@ impl InsertValue {
                 std::slice::from_raw_parts(ptr, num_indices as usize).to_vec()
             },
             dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -2741,7 +2741,7 @@ impl Alloca {
             ),
             dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
             alignment: unsafe { LLVMGetAlignment(inst) },
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -2771,7 +2771,7 @@ impl Load {
                 }
             },
             alignment: unsafe { LLVMGetAlignment(inst) },
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -2801,7 +2801,7 @@ impl Store {
                 }
             },
             alignment: unsafe { LLVMGetAlignment(inst) },
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -2816,7 +2816,7 @@ impl Fence {
                 synch_scope: SynchronizationScope::from_llvm_ref(inst),
                 mem_ordering: MemoryOrdering::from_llvm(unsafe { LLVMGetOrdering(inst) }),
             },
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -2845,9 +2845,9 @@ impl CmpXchg {
             failure_memory_ordering: MemoryOrdering::from_llvm(unsafe {
                 LLVMGetCmpXchgFailureOrdering(inst)
             }),
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             weak: unsafe { LLVMGetWeak(inst) } != 0,
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -2862,7 +2862,7 @@ impl AtomicRMW {
     ) -> Self {
         assert_eq!(unsafe { LLVMGetNumOperands(inst) }, 2);
         Self {
-            #[cfg(LLVM_VERSION_10_OR_GREATER)] // the binop-getter was added to the LLVM C API in LLVM 10
+            #[cfg(feature="llvm-10-or-greater")] // the binop-getter was added to the LLVM C API in LLVM 10
             operation: RMWBinOp::from_llvm(unsafe { LLVMGetAtomicRMWBinOp(inst) }),
             address: Operand::from_llvm_ref(unsafe { LLVMGetOperand(inst, 0) }, ctx, func_ctx),
             value: Operand::from_llvm_ref(unsafe { LLVMGetOperand(inst, 1) }, ctx, func_ctx),
@@ -2872,7 +2872,7 @@ impl AtomicRMW {
                 synch_scope: SynchronizationScope::from_llvm_ref(inst),
                 mem_ordering: MemoryOrdering::from_llvm(unsafe { LLVMGetOrdering(inst) }),
             },
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -2897,7 +2897,7 @@ impl GetElementPtr {
             },
             dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
             in_bounds: unsafe { LLVMIsInBounds(inst) } != 0,
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -2923,7 +2923,7 @@ macro_rules! typed_unop_from_llvm {
                     ),
                     to_type: ctx.types.type_from_llvm_ref(unsafe { LLVMTypeOf(inst) }),
                     dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
-                    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+                    #[cfg(feature="llvm-9-or-greater")]
                     debugloc: DebugLoc::from_llvm_with_col(inst),
                     // metadata: InstructionMetadata::from_llvm_inst(inst),
                 }
@@ -2958,7 +2958,7 @@ impl ICmp {
             operand0: Operand::from_llvm_ref(unsafe { LLVMGetOperand(inst, 0) }, ctx, func_ctx),
             operand1: Operand::from_llvm_ref(unsafe { LLVMGetOperand(inst, 1) }, ctx, func_ctx),
             dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -2977,7 +2977,7 @@ impl FCmp {
             operand0: Operand::from_llvm_ref(unsafe { LLVMGetOperand(inst, 0) }, ctx, func_ctx),
             operand1: Operand::from_llvm_ref(unsafe { LLVMGetOperand(inst, 1) }, ctx, func_ctx),
             dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -3011,7 +3011,7 @@ impl Phi {
             },
             dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
             to_type: ctx.types.type_from_llvm_ref(unsafe { LLVMTypeOf(inst) }),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -3030,7 +3030,7 @@ impl Select {
             true_value: Operand::from_llvm_ref(unsafe { LLVMGetOperand(inst, 1) }, ctx, func_ctx),
             false_value: Operand::from_llvm_ref(unsafe { LLVMGetOperand(inst, 2) }, ctx, func_ctx),
             dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -3149,7 +3149,7 @@ impl Call {
             function_attributes: callinfo.function_attributes,
             is_tail_call: unsafe { LLVMIsTailCall(inst) } != 0,
             calling_convention: callinfo.calling_convention,
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -3167,7 +3167,7 @@ impl VAArg {
             arg_list: Operand::from_llvm_ref(unsafe { LLVMGetOperand(inst, 0) }, ctx, func_ctx),
             cur_type: ctx.types.type_from_llvm_ref(unsafe { LLVMTypeOf(inst) }),
             dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -3190,7 +3190,7 @@ impl LandingPad {
             },
             dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
             cleanup: unsafe { LLVMIsCleanup(inst) } != 0,
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -3218,7 +3218,7 @@ impl CatchPad {
                     .collect()
             },
             dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -3242,7 +3242,7 @@ impl CleanupPad {
                     .collect()
             },
             dest: Name::name_or_num(unsafe { get_value_name(inst) }, &mut func_ctx.ctr),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
@@ -3274,7 +3274,7 @@ impl MemoryOrdering {
     }
 }
 
-#[cfg(LLVM_VERSION_10_OR_GREATER)]
+#[cfg(feature="llvm-10-or-greater")]
 impl RMWBinOp {
     pub(crate) fn from_llvm(rmwbo: LLVMAtomicRMWBinOp) -> Self {
         match rmwbo {
@@ -3289,9 +3289,9 @@ impl RMWBinOp {
             LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpMin => Self::Min,
             LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUMax => Self::UMax,
             LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUMin => Self::UMin,
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFAdd => Self::FAdd,
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFSub => Self::FSub,
         }
     }

--- a/src/instruction/groups.rs
+++ b/src/instruction/groups.rs
@@ -41,7 +41,7 @@ pub enum UnaryOp {
     FPToSI(super::FPToSI),
     FPToUI(super::FPToUI),
     FPTrunc(super::FPTrunc),
-    #[cfg(LLVM_VERSION_10_OR_GREATER)]
+    #[cfg(feature="llvm-10-or-greater")]
     Freeze(super::Freeze),
     IntToPtr(super::IntToPtr),
     PtrToInt(super::PtrToInt),
@@ -87,7 +87,7 @@ impl From<UnaryOp> for Instruction {
             UnaryOp::FPToSI(i) => i.into(),
             UnaryOp::FPToUI(i) => i.into(),
             UnaryOp::FPTrunc(i) => i.into(),
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             UnaryOp::Freeze(i) => i.into(),
             UnaryOp::IntToPtr(i) => i.into(),
             UnaryOp::PtrToInt(i) => i.into(),
@@ -138,7 +138,7 @@ impl TryFrom<Instruction> for UnaryOp {
             Instruction::FPToSI(i) => Ok(UnaryOp::FPToSI(i)),
             Instruction::FPToUI(i) => Ok(UnaryOp::FPToUI(i)),
             Instruction::FPTrunc(i) => Ok(UnaryOp::FPTrunc(i)),
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             Instruction::Freeze(i) => Ok(UnaryOp::Freeze(i)),
             Instruction::IntToPtr(i) => Ok(UnaryOp::IntToPtr(i)),
             Instruction::PtrToInt(i) => Ok(UnaryOp::PtrToInt(i)),
@@ -187,7 +187,7 @@ impl Typed for UnaryOp {
             UnaryOp::FPToSI(i) => types.type_of(i),
             UnaryOp::FPToUI(i) => types.type_of(i),
             UnaryOp::FPTrunc(i) => types.type_of(i),
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             UnaryOp::Freeze(i) => types.type_of(i),
             UnaryOp::IntToPtr(i) => types.type_of(i),
             UnaryOp::PtrToInt(i) => types.type_of(i),
@@ -236,7 +236,7 @@ impl HasMetadata for UnaryOp {
             UnaryOp::FPToSI(i) => i.get_metadata(),
             UnaryOp::FPToUI(i) => i.get_metadata(),
             UnaryOp::FPTrunc(i) => i.get_metadata(),
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             UnaryOp::Freeze(i) => i.get_metadata(),
             UnaryOp::IntToPtr(i) => i.get_metadata(),
             UnaryOp::PtrToInt(i) => i.get_metadata(),
@@ -285,7 +285,7 @@ impl HasResult for UnaryOp {
             UnaryOp::FPToSI(i) => i.get_result(),
             UnaryOp::FPToUI(i) => i.get_result(),
             UnaryOp::FPTrunc(i) => i.get_result(),
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             UnaryOp::Freeze(i) => i.get_result(),
             UnaryOp::IntToPtr(i) => i.get_result(),
             UnaryOp::PtrToInt(i) => i.get_result(),
@@ -356,7 +356,7 @@ impl super::UnaryOp for UnaryOp {
             UnaryOp::FPToSI(i) => i.get_operand(),
             UnaryOp::FPToUI(i) => i.get_operand(),
             UnaryOp::FPTrunc(i) => i.get_operand(),
-            #[cfg(LLVM_VERSION_10_OR_GREATER)]
+            #[cfg(feature="llvm-10-or-greater")]
             UnaryOp::Freeze(i) => i.get_operand(),
             UnaryOp::IntToPtr(i) => i.get_operand(),
             UnaryOp::PtrToInt(i) => i.get_operand(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,9 @@ pub mod basicblock;
 pub use basicblock::BasicBlock;
 pub mod constant;
 pub use constant::{Constant, ConstantRef};
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 pub mod debugloc;
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 pub use debugloc::{DebugLoc, HasDebugLoc};
 pub mod function;
 pub use function::Function;

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,5 +1,5 @@
 use crate::constant::ConstantRef;
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 use crate::debugloc::*;
 use crate::function::{Function, FunctionAttribute, GroupID};
 use crate::llvm_sys::*;
@@ -115,7 +115,7 @@ pub struct GlobalVariable {
     pub section: Option<String>,
     pub comdat: Option<Comdat>, // llvm-hs-pure has Option<String> for some reason
     pub alignment: u32,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: Vec<(String, MetadataRef<MetadataNode>)>,
 }
@@ -126,7 +126,7 @@ impl Typed for GlobalVariable {
     }
 }
 
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 impl HasDebugLoc for GlobalVariable {
     fn get_debug_loc(&self) -> &Option<DebugLoc> {
         &self.debugloc
@@ -294,7 +294,7 @@ pub struct Alignment {
 
 /// Alignment details for function pointers.
 /// See [LLVM 11 docs on Data Layout](https://releases.llvm.org/11.0.0/docs/LangRef.html#data-layout)
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct FunctionPtrAlignment {
     /// If `true`, function pointer alignment is independent of function alignment.
@@ -333,10 +333,10 @@ pub struct Alignments {
     /// Alignment for aggregate types (structs, arrays)
     agg_alignment: Alignment,
     /// Alignment for function pointers
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     fptr_alignment: FunctionPtrAlignment,
     /// Alignment for function pointers, as an `Alignment`
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     fptr_alignment_as_alignment: Alignment,
     /// Layout details for (non-function-pointer) pointers, by address space
     pointer_layouts: HashMap<AddrSpace, PointerLayout>,
@@ -363,7 +363,7 @@ impl Alignments {
                 pointee_type,
                 addr_space,
             } => match pointee_type.as_ref() {
-                #[cfg(LLVM_VERSION_9_OR_GREATER)]
+                #[cfg(feature="llvm-9-or-greater")]
                 Type::FuncType { .. } => &self.fptr_alignment_as_alignment,
                 _ => &self.ptr_alignment(*addr_space).alignment,
             },
@@ -432,7 +432,7 @@ impl Alignments {
     }
 
     /// Alignment of function pointers
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub fn fptr_alignment(&self) -> &FunctionPtrAlignment {
         &self.fptr_alignment
     }
@@ -452,7 +452,7 @@ impl Alignments {
     fn fpt_size(fpt: FPType) -> u32 {
         match fpt {
             FPType::Half => 16,
-            #[cfg(LLVM_VERSION_11_OR_GREATER)]
+            #[cfg(feature="llvm-11-or-greater")]
             FPType::BFloat => 16,
             FPType::Single => 32,
             FPType::Double => 64,
@@ -471,7 +471,7 @@ pub enum Mangling {
     MachO,
     WindowsX86COFF,
     WindowsCOFF,
-    #[cfg(LLVM_VERSION_11_OR_GREATER)]
+    #[cfg(feature="llvm-11-or-greater")]
     XCOFF,
 }
 
@@ -612,7 +612,7 @@ impl GlobalVariable {
                 }
             },
             alignment: unsafe { LLVMGetAlignment(global) },
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_no_col(global),
             // metadata: unimplemented!("metadata"),
         }
@@ -917,11 +917,11 @@ impl DataLayout {
                 assert!(chunks.next().is_none(), "datalayout 'a': Too many chunks");
                 data_layout.alignments.agg_alignment = Alignment { abi, pref };
             } else if spec.starts_with("Fi") {
-                #[cfg(LLVM_VERSION_8_OR_LOWER)]
+                #[cfg(feature="llvm-8-or-lower")]
                 {
                     panic!("datalayout: Unknown spec {:?}", spec);
                 }
-                #[cfg(LLVM_VERSION_9_OR_GREATER)]
+                #[cfg(feature="llvm-9-or-greater")]
                 {
                     let abi: u32 = spec[2 ..]
                         .parse()
@@ -934,11 +934,11 @@ impl DataLayout {
                         Alignment { abi, pref: abi };
                 }
             } else if spec.starts_with("Fn") {
-                #[cfg(LLVM_VERSION_8_OR_LOWER)]
+                #[cfg(feature="llvm-8-or-lower")]
                 {
                     panic!("datalayout: Unknown spec {:?}", spec);
                 }
-                #[cfg(LLVM_VERSION_9_OR_GREATER)]
+                #[cfg(feature="llvm-9-or-greater")]
                 {
                     let abi: u32 = spec[2 ..]
                         .parse()
@@ -963,7 +963,7 @@ impl DataLayout {
                     "o" => Mangling::MachO,
                     "x" => Mangling::WindowsX86COFF,
                     "w" => Mangling::WindowsCOFF,
-                    #[cfg(LLVM_VERSION_11_OR_GREATER)]
+                    #[cfg(feature="llvm-11-or-greater")]
                     "a" => Mangling::XCOFF,
                     _ => panic!("datalayout 'm': Unknown mangling {:?}", second_chunk),
                 };
@@ -1040,13 +1040,13 @@ impl Default for Alignments {
             /// Alignment for aggregate types (structs, arrays)
             agg_alignment: Alignment { abi: 0, pref: 64 },
             /// Alignment for function pointers
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             fptr_alignment: FunctionPtrAlignment {
                 independent: true,
                 abi: 64,
             },
             /// Alignment for function pointers, as an `Alignment`
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             fptr_alignment_as_alignment: Alignment { abi: 64, pref: 64 },
             /// Layout details for (non-function-pointer) pointers, by address space
             pointer_layouts: vec![(

--- a/src/terminator.rs
+++ b/src/terminator.rs
@@ -1,4 +1,4 @@
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 use crate::debugloc::{DebugLoc, HasDebugLoc};
 use crate::function::{CallingConvention, FunctionAttribute, ParameterAttribute};
 use crate::instruction::{HasResult, InlineAssembly};
@@ -23,7 +23,7 @@ pub enum Terminator {
     CleanupRet(CleanupRet),
     CatchRet(CatchRet),
     CatchSwitch(CatchSwitch),
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     CallBr(CallBr),
 }
 
@@ -47,13 +47,13 @@ impl Typed for Terminator {
             Terminator::CleanupRet(t) => types.type_of(t),
             Terminator::CatchRet(t) => types.type_of(t),
             Terminator::CatchSwitch(t) => types.type_of(t),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             Terminator::CallBr(t) => types.type_of(t),
         }
     }
 }
 
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 impl HasDebugLoc for Terminator {
     fn get_debug_loc(&self) -> &Option<DebugLoc> {
         match self {
@@ -68,7 +68,7 @@ impl HasDebugLoc for Terminator {
             Terminator::CleanupRet(t) => t.get_debug_loc(),
             Terminator::CatchRet(t) => t.get_debug_loc(),
             Terminator::CatchSwitch(t) => t.get_debug_loc(),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             Terminator::CallBr(t) => t.get_debug_loc(),
         }
     }
@@ -88,7 +88,7 @@ impl Display for Terminator {
             Terminator::CleanupRet(t) => write!(f, "{}", t),
             Terminator::CatchRet(t) => write!(f, "{}", t),
             Terminator::CatchSwitch(t) => write!(f, "{}", t),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             Terminator::CallBr(t) => write!(f, "{}", t),
         }
     }
@@ -109,7 +109,7 @@ impl Terminator {
             Terminator::CleanupRet(t) => &t.metadata,
             Terminator::CatchRet(t) => &t.metadata,
             Terminator::CatchSwitch(t) => &t.metadata,
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             Terminator::CallBr(t) => &t.metadata,
         }
     }
@@ -134,7 +134,7 @@ macro_rules! impl_term {
             }
         }
 
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         impl HasDebugLoc for $term {
             fn get_debug_loc(&self) -> &Option<DebugLoc> {
                 &self.debugloc
@@ -176,7 +176,7 @@ macro_rules! void_typed {
 pub struct Ret {
     /// The value being returned, or `None` if returning void.
     pub return_operand: Option<Operand>,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -192,7 +192,7 @@ impl Display for Ret {
                 Some(op) => format!("{}", op),
             },
         )?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -207,7 +207,7 @@ impl Display for Ret {
 pub struct Br {
     /// The [`Name`](../enum.Name.html) of the [`BasicBlock`](../struct.BasicBlock.html) destination.
     pub dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -218,7 +218,7 @@ void_typed!(Br);
 impl Display for Br {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "br label {}", &self.dest)?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -237,7 +237,7 @@ pub struct CondBr {
     pub true_dest: Name,
     /// The [`Name`](../enum.Name.html) of the [`BasicBlock`](../struct.BasicBlock.html) destination if the `condition` is false.
     pub false_dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -252,7 +252,7 @@ impl Display for CondBr {
             &self.true_dest,
             &self.false_dest,
         )?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -266,7 +266,7 @@ pub struct Switch {
     pub operand: Operand,
     pub dests: Vec<(ConstantRef, Name)>,
     pub default_dest: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -284,7 +284,7 @@ impl Display for Switch {
             write!(f, "{}, label {}; ", val, label)?;
         }
         write!(f, "]")?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -302,7 +302,7 @@ pub struct IndirectBr {
     /// [`BasicBlock`](../struct.BasicBlock.html)s in the current function;
     /// `IndirectBr` cannot be used to jump between functions.
     pub possible_dests: Vec<Name>,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -320,7 +320,7 @@ impl Display for IndirectBr {
             write!(f, ", label {}", dest)?;
         }
         write!(f, " ]")?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -339,7 +339,7 @@ pub struct Invoke {
     pub exception_label: Name, // Should be the name of a basic block. If the callee returns with 'resume' or another exception-handling mechanism, control flow resumes here.
     pub function_attributes: Vec<FunctionAttribute>, // llvm-hs has the equivalent of Vec<Either<GroupID, FunctionAttribute>>, but I'm not sure how the GroupID option comes up
     pub calling_convention: CallingConvention,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -381,7 +381,7 @@ impl Display for Invoke {
             &self.return_label,
             &self.exception_label,
         )?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -393,7 +393,7 @@ impl Display for Invoke {
 #[derive(PartialEq, Clone, Debug)]
 pub struct Resume {
     pub operand: Operand,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -404,7 +404,7 @@ void_typed!(Resume);
 impl Display for Resume {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "resume {}", &self.operand)?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -415,7 +415,7 @@ impl Display for Resume {
 /// See [LLVM 11 docs on the 'unreachable' instruction](https://releases.llvm.org/11.0.0/docs/LangRef.html#unreachable-instruction)
 #[derive(PartialEq, Clone, Debug)]
 pub struct Unreachable {
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -426,7 +426,7 @@ void_typed!(Unreachable);
 impl Display for Unreachable {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "unreachable")?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -440,7 +440,7 @@ pub struct CleanupRet {
     pub cleanup_pad: Operand,
     /// `None` here indicates 'unwind to caller'
     pub unwind_dest: Option<Name>,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -457,7 +457,7 @@ impl Display for CleanupRet {
                 Some(dest) => format!("label {}", dest),
             },
         )?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -470,7 +470,7 @@ impl Display for CleanupRet {
 pub struct CatchRet {
     pub catch_pad: Operand,
     pub successor: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -484,7 +484,7 @@ impl Display for CatchRet {
             &self.catch_pad,
             &self.successor,
         )?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -501,7 +501,7 @@ pub struct CatchSwitch {
     /// `None` here indicates 'unwind to caller'
     pub default_unwind_dest: Option<Name>,
     pub result: Name,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
@@ -532,7 +532,7 @@ impl Display for CatchSwitch {
                 Some(dest) => format!("label {}", dest),
             },
         )?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -541,7 +541,7 @@ impl Display for CatchSwitch {
 }
 
 /// See [LLVM 11 docs on the 'callbr' instruction](https://releases.llvm.org/11.0.0/docs/LangRef.html#callbr-instruction)
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 #[derive(PartialEq, Clone, Debug)]
 pub struct CallBr {
     pub function: Either<InlineAssembly, Operand>,
@@ -553,17 +553,17 @@ pub struct CallBr {
     pub other_labels: (), //Vec<Name>, // Should be names of basic blocks. The callee may use an inline-asm 'goto' to resume control flow at one of these places.
     pub function_attributes: Vec<FunctionAttribute>,
     pub calling_convention: CallingConvention,
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
 
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 impl_term!(CallBr, CallBr);
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 impl_hasresult!(CallBr);
 
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 impl Typed for CallBr {
     fn get_type(&self, types: &Types) -> TypeRef {
         match types.type_of(&self.function).as_ref() {
@@ -576,7 +576,7 @@ impl Typed for CallBr {
     }
 }
 
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 impl Display for CallBr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Like with `Call` and `Invoke, we choose not to include all the
@@ -597,7 +597,7 @@ impl Display for CallBr {
             }
         }
         write!(f, ") to label {}", &self.return_label)?;
-        #[cfg(LLVM_VERSION_9_OR_GREATER)]
+        #[cfg(feature="llvm-9-or-greater")]
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -658,7 +658,7 @@ impl Terminator {
             LLVMOpcode::LLVMCatchSwitch => {
                 Terminator::CatchSwitch(CatchSwitch::from_llvm_ref(term, ctx, func_ctx))
             },
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             LLVMOpcode::LLVMCallBr => {
                 Terminator::CallBr(CallBr::from_llvm_ref(term, ctx, func_ctx))
             },
@@ -686,7 +686,7 @@ impl Ret {
                 )),
                 n => panic!("Ret instruction with {} operands", n),
             },
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(term),
             // metadata: InstructionMetadata::from_llvm_inst(term),
         }
@@ -702,7 +702,7 @@ impl Br {
                 .get(unsafe { &op_to_bb(LLVMGetOperand(term, 0)) })
                 .expect("Failed to find destination bb in map")
                 .clone(),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(term),
             // metadata: InstructionMetadata::from_llvm_inst(term),
         }
@@ -728,7 +728,7 @@ impl CondBr {
                 .get(unsafe { &op_to_bb(LLVMGetOperand(term, 1)) })
                 .expect("Failed to find false-destination in bb map")
                 .clone(),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(term),
             // metadata: InstructionMetadata::from_llvm_inst(term),
         }
@@ -764,7 +764,7 @@ impl Switch {
                 .get(unsafe { &LLVMGetSwitchDefaultDest(term) })
                 .expect("Failed to find switch default destination in map")
                 .clone(),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(term),
             // metadata: InstructionMetadata::from_llvm_inst(term),
         }
@@ -791,7 +791,7 @@ impl IndirectBr {
                     })
                     .collect()
             },
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(term),
             // metadata: InstructionMetadata::from_llvm_inst(term),
         }
@@ -823,7 +823,7 @@ impl Invoke {
                 .clone(),
             function_attributes: callinfo.function_attributes,
             calling_convention: callinfo.calling_convention,
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(term),
             // metadata: InstructionMetadata::from_llvm_inst(term),
         }
@@ -839,7 +839,7 @@ impl Resume {
         assert_eq!(unsafe { LLVMGetNumOperands(term) }, 1);
         Self {
             operand: Operand::from_llvm_ref(unsafe { LLVMGetOperand(term, 0) }, ctx, func_ctx),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(term),
             // metadata: InstructionMetadata::from_llvm_inst(term),
         }
@@ -850,7 +850,7 @@ impl Unreachable {
     pub(crate) fn from_llvm_ref(term: LLVMValueRef) -> Self {
         assert_eq!(unsafe { LLVMGetNumOperands(term) }, 0);
         Self {
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(term),
             // metadata: InstructionMetadata::from_llvm_inst(term),
         }
@@ -886,7 +886,7 @@ impl CleanupRet {
                     )
                 }
             },
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(term),
             // metadata: InstructionMetadata::from_llvm_inst(term),
         }
@@ -906,7 +906,7 @@ impl CatchRet {
                 .get(unsafe { &LLVMGetSuccessor(term, 0) })
                 .expect("Failed to find CatchRet successor in map")
                 .clone(),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(term),
             // metadata: InstructionMetadata::from_llvm_inst(term),
         }
@@ -952,14 +952,14 @@ impl CatchSwitch {
                 }
             },
             result: Name::name_or_num(unsafe { get_value_name(term) }, &mut func_ctx.ctr),
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(term),
             // metadata: InstructionMetadata::from_llvm_inst(term),
         }
     }
 }
 
-#[cfg(LLVM_VERSION_9_OR_GREATER)]
+#[cfg(feature="llvm-9-or-greater")]
 impl CallBr {
     pub(crate) fn from_llvm_ref(
         term: LLVMValueRef,
@@ -981,7 +981,7 @@ impl CallBr {
             other_labels: (),
             function_attributes: callinfo.function_attributes,
             calling_convention: callinfo.calling_convention,
-            #[cfg(LLVM_VERSION_9_OR_GREATER)]
+            #[cfg(feature="llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(term),
             // metadata: InstructionMetadata::from_llvm_inst(term),
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -34,7 +34,7 @@ pub enum Type {
     VectorType {
         element_type: TypeRef,
         num_elements: usize,
-        #[cfg(LLVM_VERSION_11_OR_GREATER)]
+        #[cfg(feature="llvm-11-or-greater")]
         scalable: bool,
     },
     /// Struct and Array types (but not vector types) are "aggregate types" and cannot be produced by
@@ -97,16 +97,16 @@ impl Display for Type {
             Type::VectorType {
                 element_type,
                 num_elements,
-                #[cfg(LLVM_VERSION_11_OR_GREATER)]
+                #[cfg(feature="llvm-11-or-greater")]
                 scalable,
             } => {
-                #[cfg(LLVM_VERSION_11_OR_GREATER)]
+                #[cfg(feature="llvm-11-or-greater")]
                 if *scalable {
                     write!(f, "<vscale x {} x {}>", num_elements, element_type)
                 } else {
                     write!(f, "<{} x {}>", num_elements, element_type)
                 }
-                #[cfg(LLVM_VERSION_10_OR_LOWER)]
+                #[cfg(feature="llvm-10-or-lower")]
                 write!(f, "<{} x {}>", num_elements, element_type)
             },
             Type::ArrayType {
@@ -148,7 +148,7 @@ impl Display for Type {
 #[allow(non_camel_case_types)]
 pub enum FPType {
     Half,
-    #[cfg(LLVM_VERSION_11_OR_GREATER)]
+    #[cfg(feature="llvm-11-or-greater")]
     BFloat,
     Single,
     Double,
@@ -167,7 +167,7 @@ impl Display for FPType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             FPType::Half => write!(f, "half"),
-            #[cfg(LLVM_VERSION_11_OR_GREATER)]
+            #[cfg(feature="llvm-11-or-greater")]
             FPType::BFloat => write!(f, "bfloat"),
             FPType::Single => write!(f, "float"),
             FPType::Double => write!(f, "double"),
@@ -424,7 +424,7 @@ impl TypesBuilder {
     }
 
     /// Get a vector type
-    #[cfg(LLVM_VERSION_11_OR_GREATER)]
+    #[cfg(feature="llvm-11-or-greater")]
     pub fn vector_of(&mut self, element_type: TypeRef, num_elements: usize, scalable: bool) -> TypeRef {
         self.vec_types
             .lookup_or_insert((element_type.clone(), num_elements, scalable), || Type::VectorType {
@@ -434,7 +434,7 @@ impl TypesBuilder {
             })
     }
     /// Get a vector type
-    #[cfg(LLVM_VERSION_10_OR_LOWER)]
+    #[cfg(feature="llvm-10-or-lower")]
     pub fn vector_of(&mut self, element_type: TypeRef, num_elements: usize) -> TypeRef {
         self.vec_types
             .lookup_or_insert((element_type.clone(), num_elements, false), || Type::VectorType {
@@ -668,7 +668,7 @@ impl Types {
     }
 
     /// Get a vector type
-    #[cfg(LLVM_VERSION_11_OR_GREATER)]
+    #[cfg(feature="llvm-11-or-greater")]
     pub fn vector_of(&self, element_type: TypeRef, num_elements: usize, scalable: bool) -> TypeRef {
         self.vec_types
             .lookup(&(element_type.clone(), num_elements, scalable))
@@ -680,7 +680,7 @@ impl Types {
                 })
             })
     }
-    #[cfg(LLVM_VERSION_10_OR_LOWER)]
+    #[cfg(feature="llvm-10-or-lower")]
     pub fn vector_of(&self, element_type: TypeRef, num_elements: usize) -> TypeRef {
         self.vec_types
             .lookup(&(element_type.clone(), num_elements, false))
@@ -773,11 +773,11 @@ impl Types {
             Type::FuncType { result_type, param_types, is_var_arg } => {
                 self.func_type(result_type.clone(), param_types.clone(), *is_var_arg)
             },
-            #[cfg(LLVM_VERSION_11_OR_GREATER)]
+            #[cfg(feature="llvm-11-or-greater")]
             Type::VectorType { element_type, num_elements, scalable } => {
                 self.vector_of(element_type.clone(), *num_elements, *scalable)
             },
-            #[cfg(LLVM_VERSION_10_OR_LOWER)]
+            #[cfg(feature="llvm-10-or-lower")]
             Type::VectorType { element_type, num_elements } => {
                 self.vector_of(element_type.clone(), *num_elements)
             },
@@ -880,13 +880,13 @@ impl TypesBuilder {
             },
             LLVMTypeKind::LLVMVectorTypeKind => {
                 let element_type = self.type_from_llvm_ref(unsafe { LLVMGetElementType(ty) });
-                #[cfg(LLVM_VERSION_11_OR_GREATER)]
+                #[cfg(feature="llvm-11-or-greater")]
                 let ret = self.vector_of(element_type, unsafe { LLVMGetVectorSize(ty) as usize }, false);
-                #[cfg(LLVM_VERSION_10_OR_LOWER)]
+                #[cfg(feature="llvm-10-or-lower")]
                 let ret = self.vector_of(element_type, unsafe { LLVMGetVectorSize(ty) as usize });
                 ret
             },
-            #[cfg(LLVM_VERSION_11_OR_GREATER)]
+            #[cfg(feature="llvm-11-or-greater")]
             LLVMTypeKind::LLVMScalableVectorTypeKind => {
                 let element_type = self.type_from_llvm_ref(unsafe { LLVMGetElementType(ty) });
                 self.vector_of(element_type, unsafe { LLVMGetVectorSize(ty) as usize }, true)
@@ -946,7 +946,7 @@ impl TypesBuilder {
                 )
             },
             LLVMTypeKind::LLVMHalfTypeKind => self.fp(FPType::Half),
-            #[cfg(LLVM_VERSION_11_OR_GREATER)]
+            #[cfg(feature="llvm-11-or-greater")]
             LLVMTypeKind::LLVMBFloatTypeKind => self.fp(FPType::BFloat),
             LLVMTypeKind::LLVMFloatTypeKind => self.fp(FPType::Single),
             LLVMTypeKind::LLVMDoubleTypeKind => self.fp(FPType::Double),

--- a/tests/llvm_10_tests.rs
+++ b/tests/llvm_10_tests.rs
@@ -1,4 +1,4 @@
-#![cfg(LLVM_VERSION_10_OR_GREATER)]
+#![cfg(feature="llvm-10-or-greater")]
 
 //! These tests simply ensure that we can parse all of the `.bc` files in LLVM 10's `test/Bitcode` directory without crashing.
 //! We only include the `.bc` files which are new or have changed since LLVM 9 (older ones are covered in llvm_9_tests.rs or llvm_8_tests.rs).
@@ -53,12 +53,12 @@ fn freeze() {
     assert_eq!(freeze.dest, Name::from(32));
     assert_eq!(&format!("{}", freeze), "%32 = freeze i32 10");
     let freeze: &instruction::Freeze = &bb.instrs[9].clone().try_into().unwrap_or_else(|_| panic!("Expected a freeze, got {:?}", &bb.instrs[9]));
-    #[cfg(LLVM_VERSION_11_OR_GREATER)]
+    #[cfg(feature="llvm-11-or-greater")]
     assert_eq!(freeze.operand, Operand::LocalOperand {
         name: Name::from("vop"),
         ty: module.types.vector_of(module.types.i32(), 2, false),
     });
-    #[cfg(LLVM_VERSION_10_OR_LOWER)]
+    #[cfg(feature="llvm-10-or-lower")]
     assert_eq!(freeze.operand, Operand::LocalOperand {
         name: Name::from("vop"),
         ty: module.types.vector_of(module.types.i32(), 2),

--- a/tests/llvm_11_tests.rs
+++ b/tests/llvm_11_tests.rs
@@ -1,4 +1,4 @@
-#![cfg(LLVM_VERSION_11_OR_GREATER)]
+#![cfg(feature="llvm-11-or-greater")]
 
 //! These tests simply ensure that we can parse all of the `.bc` files in LLVM 11's `test/Bitcode` directory without crashing.
 //! We only include the `.bc` files which are new or have changed since LLVM 10 (older ones are covered in other llvm_*_tests.rs).

--- a/tests/llvm_8_tests.rs
+++ b/tests/llvm_8_tests.rs
@@ -153,12 +153,12 @@ fn DILocation_implicit_code_extra_checks() {
     assert_eq!(invoke.arguments[1].0, Operand::ConstantOperand(ConstantRef::new(Constant::Int { bits: 32, value: 0 })));
     assert_eq!(invoke.return_label, Name::from("invoke.cont"));
     assert_eq!(invoke.exception_label, Name::from("lpad"));
-    #[cfg(LLVM_VERSION_8_OR_LOWER)]
+    #[cfg(feature="llvm-8-or-lower")]
     assert_eq!(
         &format!("{}", invoke),
         "%0 = invoke @_ZN1A3fooEi(%struct.A* %a, i32 0) to label %invoke.cont unwind label %lpad",
     );
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     assert_eq!(
         &format!("{}", invoke),
         "%0 = invoke @_ZN1A3fooEi(%struct.A* %a, i32 0) to label %invoke.cont unwind label %lpad (with debugloc)",
@@ -189,9 +189,9 @@ fn DILocation_implicit_code_extra_checks() {
     assert_eq!(landingpad.clauses.len(), 1);
     assert_eq!(landingpad.cleanup, false);
     assert_eq!(landingpad.dest, Name::Number(1));
-    #[cfg(LLVM_VERSION_8_OR_LOWER)]
+    #[cfg(feature="llvm-8-or-lower")]
     assert_eq!(&format!("{}", landingpad), "%1 = landingpad { i8*, i32 }");
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     assert_eq!(&format!("{}", landingpad), "%1 = landingpad { i8*, i32 } (with debugloc)");
     let eval: &instruction::ExtractValue = &lpad.instrs[1]
         .clone()
@@ -207,9 +207,9 @@ fn DILocation_implicit_code_extra_checks() {
     assert_eq!(eval.indices.len(), 1);
     assert_eq!(eval.indices[0], 0);
     assert_eq!(eval.dest, Name::Number(2));
-    #[cfg(LLVM_VERSION_8_OR_LOWER)]
+    #[cfg(feature="llvm-8-or-lower")]
     assert_eq!(&format!("{}", eval), "%2 = extractvalue { i8*, i32 } %1, 0");
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     assert_eq!(&format!("{}", eval), "%2 = extractvalue { i8*, i32 } %1, 0 (with debugloc)");
 
     // From this point on, our numbers are off by 2 instead of 1, due to
@@ -226,9 +226,9 @@ fn DILocation_implicit_code_extra_checks() {
     assert_eq!(landingpad.result_type, expected_landingpad_resultty);
     assert_eq!(landingpad.clauses.len(), 0);
     assert_eq!(landingpad.cleanup, true);
-    #[cfg(LLVM_VERSION_8_OR_LOWER)]
+    #[cfg(feature="llvm-8-or-lower")]
     assert_eq!(&format!("{}", landingpad), "%10 = landingpad { i8*, i32 } cleanup");
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     assert_eq!(&format!("{}", landingpad), "%10 = landingpad { i8*, i32 } cleanup (with debugloc)");
     let eval: &instruction::ExtractValue = &lpad1.instrs[3]
         .clone()
@@ -244,9 +244,9 @@ fn DILocation_implicit_code_extra_checks() {
     assert_eq!(eval.indices.len(), 1);
     assert_eq!(eval.indices[0], 1);
     assert_eq!(eval.dest, Name::Number(12));
-    #[cfg(LLVM_VERSION_8_OR_LOWER)]
+    #[cfg(feature="llvm-8-or-lower")]
     assert_eq!(&format!("{}", eval), "%12 = extractvalue { i8*, i32 } %10, 1");
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     assert_eq!(&format!("{}", eval), "%12 = extractvalue { i8*, i32 } %10, 1 (with debugloc)");
 
     let trycont = func
@@ -257,9 +257,9 @@ fn DILocation_implicit_code_extra_checks() {
         .clone()
         .try_into()
         .unwrap_or_else(|_| panic!("Expected an unreachable, got {:?}", &trycont.term));
-    #[cfg(LLVM_VERSION_8_OR_LOWER)]
+    #[cfg(feature="llvm-8-or-lower")]
     assert_eq!(&format!("{}", u), "unreachable");
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     assert_eq!(&format!("{}", u), "unreachable (with debugloc)");
 
     let ehresume = func
@@ -283,9 +283,9 @@ fn DILocation_implicit_code_extra_checks() {
     assert_eq!(ival.indices.len(), 1);
     assert_eq!(ival.indices[0], 0);
     assert_eq!(ival.dest, Name::from("lpad.val"));
-    #[cfg(LLVM_VERSION_8_OR_LOWER)]
+    #[cfg(feature="llvm-8-or-lower")]
     assert_eq!(&format!("{}", ival), "%lpad.val = insertvalue { i8*, i32 } undef, i8* %exn4, 0");
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     assert_eq!(&format!("{}", ival), "%lpad.val = insertvalue { i8*, i32 } undef, i8* %exn4, 0 (with debugloc)");
     let ival2: &instruction::InsertValue = &ehresume.instrs[3]
         .clone()
@@ -308,9 +308,9 @@ fn DILocation_implicit_code_extra_checks() {
     assert_eq!(ival2.indices.len(), 1);
     assert_eq!(ival2.indices[0], 1);
     assert_eq!(ival2.dest, Name::from("lpad.val6"));
-    #[cfg(LLVM_VERSION_8_OR_LOWER)]
+    #[cfg(feature="llvm-8-or-lower")]
     assert_eq!(&format!("{}", ival2), "%lpad.val6 = insertvalue { i8*, i32 } %lpad.val, i32 %sel5, 1");
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     assert_eq!(&format!("{}", ival2), "%lpad.val6 = insertvalue { i8*, i32 } %lpad.val, i32 %sel5, 1 (with debugloc)");
     let resume: &terminator::Resume = &ehresume
         .term
@@ -324,9 +324,9 @@ fn DILocation_implicit_code_extra_checks() {
             ty: expected_landingpad_resultty.clone()
         }
     );
-    #[cfg(LLVM_VERSION_8_OR_LOWER)]
+    #[cfg(feature="llvm-8-or-lower")]
     assert_eq!(&format!("{}", resume), "resume { i8*, i32 } %lpad.val6");
-    #[cfg(LLVM_VERSION_9_OR_GREATER)]
+    #[cfg(feature="llvm-9-or-greater")]
     assert_eq!(&format!("{}", resume), "resume { i8*, i32 } %lpad.val6 (with debugloc)");
 }
 
@@ -353,8 +353,8 @@ fn atomics() {
     assert_eq!(atomicrmw.value, Operand::ConstantOperand(ConstantRef::new(Constant::Int { bits: 32, value: 12 })));
     assert_eq!(atomicrmw.dest, Name::from("atomicrmw.xchg"));
     assert_eq!(module.type_of(atomicrmw), module.types.i32());
-    #[cfg(LLVM_VERSION_9_OR_LOWER)]
+    #[cfg(feature="llvm-9-or-lower")]
     assert_eq!(&format!("{}", atomicrmw), "%atomicrmw.xchg = atomicrmw i32* %word, i32 12 not_atomic"); // I'm not sure why it's not_atomic for LLVM 9 and lower, but monotonic for LLVM 10+
-    #[cfg(LLVM_VERSION_10_OR_GREATER)]
+    #[cfg(feature="llvm-10-or-greater")]
     assert_eq!(&format!("{}", atomicrmw), "%atomicrmw.xchg = atomicrmw xchg i32* %word, i32 12 monotonic");
 }

--- a/tests/llvm_9_tests.rs
+++ b/tests/llvm_9_tests.rs
@@ -1,4 +1,4 @@
-#![cfg(LLVM_VERSION_9_OR_GREATER)]
+#![cfg(feature="llvm-9-or-greater")]
 
 //! These tests simply ensure that we can parse all of the `.bc` files in LLVM 9's `test/Bitcode` directory without crashing.
 //! We only include the `.bc` files which are new or have changed since LLVM 8 (older ones are covered in llvm_8_tests.rs).


### PR DESCRIPTION
I had a problem with rust-analyzer thinking the `debugloc` fields were not present in most strutcs even though I'm building with llvm-11. Seing that those fields depend on CFG flags set in build.rs made mes suspect that this was the cause.

To fix it, I added some extra feature flags to Cargo.toml which do the same thing. It's a bit ugly, but the inheritance of features at least makes the amount of needed features linear in the amount of llvm versions supported.

Sidenote: after making this change, I found a r-a issue claiming to fix this kind of problem, but it seems like it's not fully fixed https://github.com/rust-analyzer/rust-analyzer/pull/4296. Especially as if I removed the debugloc-fields, it would tell me that the field is needed. We may want to report this to them