### PR TITLE
Add function for adding named structs

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -805,6 +805,12 @@ impl Types {
     pub fn blank_for_testing() -> Self {
         TypesBuilder::new().build()
     }
+
+    pub fn add_named_struct_def(&mut self, name: String, ty: NamedStructDef) {
+        self.named_struct_defs.insert(name.clone(), ty.clone());
+
+        self.named_struct_types.map.insert(name.clone(), TypeRef::new(Type::NamedStructType { name }));
+    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
I finally got around to bumping my version up to 0.7 as per #8, however, a few of my tests require adding named structs to the types list which I found no way of doing. I cobbled together this, but I'm not sure if it's the most optimal way.

If this makes sense, I can add some doc comments as well