### PR TITLE
Add `llvm-13` case to `llvm_version`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,5 +52,6 @@ pub fn llvm_version() -> &'static str {
     case!("llvm-10");
     case!("llvm-11");
     case!("llvm-12");
+    case!("llvm-13");
     unreachable!()
 }


### PR DESCRIPTION
I was trying to think of test to catch this sort of thing, but I wasn't sure what would be most appropriate.

If you would like to suggest something, I would be happy to add it to this PR.