### PR TITLE
Add GitHub Actions CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test
+
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        llvm:
+        - 9
+        - 10
+        - 11
+        - 12
+        - 13
+        - 14
+        - 15
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install LLVM ${{ matrix.llvm }}
+        run: curl https://apt.llvm.org/llvm.sh | sudo bash  -s -- ${{ matrix.llvm }}
+      
+      - name: Install Polly ${{ matrix.llvm }}
+        run: sudo apt-get install -y libpolly-${{ matrix.llvm }}-dev
+        if: matrix.llvm >= 14
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --features=llvm-${{ matrix.llvm }}
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features=llvm-${{ matrix.llvm }}


### PR DESCRIPTION
This tests the library on all LLVM versions on push and PRs.

LLVM 8 is too old and apt.llvm.org doesn't support it, so not included here.

Unfortunately, the `--features=llvm-15` is breaking for now.