### PR TITLE
build: enable dynamic linking in llvm-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,15 @@ llvm-13-strict = ["llvm-13", "llvm-sys-130/strict-versioning"]
 llvm-14-strict = ["llvm-14", "llvm-sys-140/strict-versioning"]
 llvm-15-strict = ["llvm-15", "llvm-sys-150/strict-versioning"]
 
+# As with the strict feature above, we cannot enable it globally, as it would
+# activate all the llvm-sys-* dependencies, so have a single feature for each
+# version to enable dynamic linking. We only allow this for llvm-sys versions
+# that have this feature (>=llvm-sys-120).
+llvm-12-dynamic = ["llvm-12", "llvm-sys-120/prefer-dynamic"]
+llvm-13-dynamic = ["llvm-13", "llvm-sys-130/prefer-dynamic"]
+llvm-14-dynamic = ["llvm-14", "llvm-sys-140/prefer-dynamic"]
+llvm-15-dynamic = ["llvm-15", "llvm-sys-150/prefer-dynamic"]
+
 [package.metadata.docs.rs]
 # Generate docs.rs documentation with the llvm-10 feature
 features = ["llvm-10"]


### PR DESCRIPTION
Expose the `prefer-dynamic` feature of `llvm-sys` for versions that support it. As with the `strict-versioning` feature, we need to do this via separate features for each `llvm-sys` version due to cargo limitations.

This fixes the build on my system (LLVM 13, openSUSE Leap 15.4). `cargo b -F llvm-13-dynamic` builds fine, but otherwise (`llvm-13` or `llvm-13-strict`) I get:

```
$ cargo b -F llvm-13
   Compiling llvm-sys v130.1.1
error: failed to run custom build command for `llvm-sys v130.1.1`

Caused by:
  process didn't exit successfully: `/home/carlos/dev/llvm-ir/target/debug/build/llvm-sys-13e6f31bd6f6f99c/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=LLVM_SYS_130_PREFIX
  cargo:rerun-if-env-changed=LLVM_SYS_130_IGNORE_BLOCKLIST
  cargo:rerun-if-env-changed=LLVM_SYS_130_STRICT_VERSIONING
  cargo:rerun-if-env-changed=LLVM_SYS_130_NO_CLEAN_CFLAGS
  cargo:rerun-if-env-changed=LLVM_SYS_130_USE_DEBUG_MSVCRT
  cargo:rerun-if-env-changed=LLVM_SYS_130_FFI_WORKAROUND
  TARGET = Some("x86_64-unknown-linux-gnu")
  OPT_LEVEL = Some("0")
  HOST = Some("x86_64-unknown-linux-gnu")
  cargo:rerun-if-env-changed=CC_x86_64-unknown-linux-gnu
  CC_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CC_x86_64_unknown_linux_gnu
  CC_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CC
  HOST_CC = None
  cargo:rerun-if-env-changed=CC
  CC = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
  CFLAGS_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
  CFLAGS_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CFLAGS
  HOST_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = Some("-I/usr/include  -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS ")
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("true")
  CARGO_CFG_TARGET_FEATURE = Some("fxsr,sse,sse2")
  running: "cc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64" "-I/usr/include" "-D_GNU_SOURCE" "-D__STDC_CONSTANT_MACROS" "-D__STDC_FORMAT_MACROS" "-D__STDC_LIMIT_MACROS" "-o" "/home/carlos/dev/llvm-ir/target/debug/build/llvm-sys-f9fcdf9a424cd367/out/wrappers/target.o" "-c" "wrappers/target.c"
  exit status: 0
  cargo:rerun-if-env-changed=AR_x86_64-unknown-linux-gnu
  AR_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=AR_x86_64_unknown_linux_gnu
  AR_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_AR
  HOST_AR = None
  cargo:rerun-if-env-changed=AR
  AR = None
  cargo:rerun-if-env-changed=ARFLAGS_x86_64-unknown-linux-gnu
  ARFLAGS_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=ARFLAGS_x86_64_unknown_linux_gnu
  ARFLAGS_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_ARFLAGS
  HOST_ARFLAGS = None
  cargo:rerun-if-env-changed=ARFLAGS
  ARFLAGS = None
  running: ZERO_AR_DATE="1" "ar" "cq" "/home/carlos/dev/llvm-ir/target/debug/build/llvm-sys-f9fcdf9a424cd367/out/libtargetwrappers.a" "/home/carlos/dev/llvm-ir/target/debug/build/llvm-sys-f9fcdf9a424cd367/out/wrappers/target.o"
  exit status: 0
  running: "ar" "s" "/home/carlos/dev/llvm-ir/target/debug/build/llvm-sys-f9fcdf9a424cd367/out/libtargetwrappers.a"
  exit status: 0
  cargo:rustc-link-lib=static=targetwrappers
  cargo:rustc-link-search=native=/home/carlos/dev/llvm-ir/target/debug/build/llvm-sys-f9fcdf9a424cd367/out
  cargo:config_path=llvm-config
  cargo:libdir=/usr/lib64

  cargo:rustc-link-search=native=/usr/lib64


  --- stderr
  thread 'main' panicked at 'failed to get link libraries from llvm-config: [("static", Custom { kind: Other, error: "llvm-config failed with error code Some(1)" })]', /home/carlos/.cargo/registry/src/index.crates.io-6f17d22bba15001f/llvm-sys-130.1.1/build.rs:432:5
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```