### PR TITLE
Add source element type for GEP instructions

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1588,6 +1588,8 @@ pub struct GetElementPtr {
     pub in_bounds: bool,
     #[cfg(feature = "llvm-9-or-greater")]
     pub debugloc: Option<DebugLoc>,
+    #[cfg(feature = "llvm-14-or-greater")]
+    pub source_element_type: TypeRef
     // --TODO not yet implemented-- pub metadata: InstructionMetadata,
 }
 
@@ -2992,6 +2994,8 @@ impl GetElementPtr {
             in_bounds: unsafe { LLVMIsInBounds(inst) } != 0,
             #[cfg(feature = "llvm-9-or-greater")]
             debugloc: DebugLoc::from_llvm_with_col(inst),
+            #[cfg(feature = "llvm-14-or-greater")]
+            source_element_type: ctx.types.type_from_llvm_ref(unsafe { LLVMGetGEPSourceElementType(inst) }),
             // metadata: InstructionMetadata::from_llvm_inst(inst),
         }
     }


### PR DESCRIPTION
This uses `LLVMGetGEPSourceElementType`, which is present since llvm 14 (see https://github.com/llvm/llvm-project/commit/573a9bc4ad7fed92db5105ea75e0f9573712f973). It is necessary for analyzing LLVM 15.x and above, since the element type is no longer implicit in the pointer type due to opaque pointers

I did not see this exposed in the current API, so I implemented this based on `loaded_ty` in `Load`

Tested with LLVM 12, 14, and 15