### PR TITLE
Add Github Actions CI (v2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         - 13
         - 14
         - 15
+        - 16
 
     steps:
       - name: Checkout sources
@@ -37,14 +38,20 @@ jobs:
           profile: minimal
           toolchain: stable
 
-      - name: Build
+      - name: Build Debug
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --features=llvm-${{ matrix.llvm }}
 
+      - name: Build Release
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --features=llvm-${{ matrix.llvm }}
+
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features=llvm-${{ matrix.llvm }}
+          args: --release --features=llvm-${{ matrix.llvm }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
         run: sudo apt-get install -y libpolly-${{ matrix.llvm }}-dev
         if: matrix.llvm >= 14
 
+      - name: Install zstd
+        run: sudo apt-get install -y zstd
+        if: matrix.llvm >= 16
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test
+
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        llvm:
+        - 9
+        - 10
+        - 11
+        - 12
+        - 13
+        - 14
+        - 15
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install LLVM ${{ matrix.llvm }}
+        run: curl https://apt.llvm.org/llvm.sh | sudo bash  -s -- ${{ matrix.llvm }}
+      
+      - name: Install Polly ${{ matrix.llvm }}
+        run: sudo apt-get install -y libpolly-${{ matrix.llvm }}-dev
+        if: matrix.llvm >= 14
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --features=llvm-${{ matrix.llvm }}
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features=llvm-${{ matrix.llvm }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         if: matrix.llvm >= 14
 
       - name: Install zstd
-        run: sudo apt-get install -y zstd
+        run: sudo apt-get install -y libzstd-dev
         if: matrix.llvm >= 16
 
       - name: Install Rust toolchain


### PR DESCRIPTION
This was originally added by @kaoet in #40 . However, they apparently ran into test failures for it. The detailed logs for the CI job from that PR has since expired, so I can't be sure, but it is possibly the issue seen in #44 where tests in debug hit a `SIGILL` from a bug in `LLVMGetOrdering`

I re-based the PR, and made the tests run with `--release`, which works around the issue. I also added llvm-16 to the matrix, since we support that now

You can see the successful CI run here:
https://github.com/Benjins/llvm-ir/actions/runs/7071283452

There are some warnings (mostly from unused doc comments in `module.rs`), but no errors/test failures