### PR TITLE
improve Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,18 +51,18 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          # LLVM 11 doesn't work with -strict, see #53
-          args: ${{ matrix.llvm == '11' && format('--features=llvm-{0}', matrix.llvm) || format('--features=llvm-{0}-strict', matrix.llvm) }}
+          # LLVM 11 doesn't work with strict-versioning, see #53
+          args: ${{ format('--features=llvm-{0}{1}', matrix.llvm, matrix.llvm != '11' && ',strict-versioning' || '') }}
 
       - name: Build Release
         uses: actions-rs/cargo@v1
         with:
           command: build
-          # LLVM 11 doesn't work with -strict, see #53
-          args: ${{ matrix.llvm == '11' && format('--release --features=llvm-{0}', matrix.llvm) || format('--release --features=llvm-{0}-strict', matrix.llvm) }}
+          # LLVM 11 doesn't work with strict-versioning, see #53
+          args: ${{ format('--release --features=llvm-{0}{1}', matrix.llvm, matrix.llvm != '11' && ',strict-versioning' || '') }}
 
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: ${{ matrix.llvm == '11' && format('--release --features=llvm-{0}', matrix.llvm) || format('--release --features=llvm-{0}-strict', matrix.llvm) }}
+          args: ${{ format('--release --features=llvm-{0}{1}', matrix.llvm, matrix.llvm != '11' && ',strict-versioning' || '') }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,46 +70,35 @@ llvm-16-or-lower = ["llvm-17-or-lower"]
 llvm-17-or-lower = []
 ###
 
-# We'd like to have a "strict-versioning" feature which enables the
-# corresponding feature in llvm-sys: i.e., requires an exact
-# match between the system LLVM version and the version selected with the above
-# features. For more information see the llvm-sys README.
-# Unfortunately, there is currently no way to enable a feature on an optional
-# dependency without also activating the optional dependency.
-# (See https://github.com/rust-lang/cargo/issues/3494.)
-# This means that a declaration like the following:
-# strict-versioning = ["llvm-sys-80/strict-versioning", "llvm-sys-90/strict-versioning", "llvm-sys-100/strict-versioning", ...]
-# would mean that llvm-sys-80, llvm-sys-90, llvm-sys-100, ...
-# would all be enabled, along with their strict-versioning features.
-# This would increase build times as we're building unnecessary crates; and
-# more importantly, it would require the user to have all of these LLVM versions
-# available on their system.
-# Instead, as a workaround, we'll have a separate strict-versioning feature for
-# each LLVM version. This will enable the corresponding LLVM version feature,
-# and the "strict-versioning" feature on the corresponding llvm-sys dependency.
-# That means that we will require an exact match between the system LLVM
-# version and the LLVM version chosen here.
-llvm-8-strict = ["llvm-8", "llvm-sys-80/strict-versioning"]
-llvm-9-strict = ["llvm-9", "llvm-sys-90/strict-versioning"]
-llvm-10-strict = ["llvm-10", "llvm-sys-100/strict-versioning"]
-llvm-11-strict = ["llvm-11", "llvm-sys-110/strict-versioning"]
-llvm-12-strict = ["llvm-12", "llvm-sys-120/strict-versioning"]
-llvm-13-strict = ["llvm-13", "llvm-sys-130/strict-versioning"]
-llvm-14-strict = ["llvm-14", "llvm-sys-140/strict-versioning"]
-llvm-15-strict = ["llvm-15", "llvm-sys-150/strict-versioning"]
-llvm-16-strict = ["llvm-16", "llvm-sys-160/strict-versioning"]
-llvm-17-strict = ["llvm-17", "llvm-sys-170/strict-versioning"]
+# The `strict-versioning` feature requires an exact match between the
+# system LLVM version and the version selected with the above features.
+#
+# The `?` in the below ensures that we only enable the feature if the dependency
+# is already present.
+# This avoids activating all the optional dependencies when `strict-versioning`
+# is activated.
+strict-versioning = [
+    "llvm-sys-80?/strict-versioning",
+    "llvm-sys-90?/strict-versioning",
+    "llvm-sys-100?/strict-versioning",
+    "llvm-sys-110?/strict-versioning",
+    "llvm-sys-120?/strict-versioning",
+    "llvm-sys-130?/strict-versioning",
+    "llvm-sys-140?/strict-versioning",
+    "llvm-sys-150?/strict-versioning",
+    "llvm-sys-160?/strict-versioning",
+    "llvm-sys-170?/strict-versioning",
+]
 
-# As with the strict feature above, we cannot enable it globally, as it would
-# activate all the llvm-sys-* dependencies, so have a single feature for each
-# version to enable dynamic linking. We only allow this for llvm-sys versions
-# that have this feature (>=llvm-sys-120).
-llvm-12-dynamic = ["llvm-12", "llvm-sys-120/prefer-dynamic"]
-llvm-13-dynamic = ["llvm-13", "llvm-sys-130/prefer-dynamic"]
-llvm-14-dynamic = ["llvm-14", "llvm-sys-140/prefer-dynamic"]
-llvm-15-dynamic = ["llvm-15", "llvm-sys-150/prefer-dynamic"]
-llvm-16-dynamic = ["llvm-16", "llvm-sys-160/prefer-dynamic"]
-llvm-17-dynamic = ["llvm-17", "llvm-sys-170/prefer-dynamic"]
+# The `prefer-dynamic` feature is only available on llvm-sys versions >= 120.
+prefer-dynamic = [
+    "llvm-sys-120?/prefer-dynamic",
+    "llvm-sys-130?/prefer-dynamic",
+    "llvm-sys-140?/prefer-dynamic",
+    "llvm-sys-150?/prefer-dynamic",
+    "llvm-sys-160?/prefer-dynamic",
+    "llvm-sys-170?/prefer-dynamic",
+]
 
 [package.metadata.docs.rs]
 # Generate docs.rs documentation with the llvm-10 feature

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ flag. This means that a single crate version can be used for any supported LLVM
 version. Currently, `llvm-ir` supports LLVM versions 8 through 17, selected by
 feature flags `llvm-8` through `llvm-17`.
 
-`llvm-ir` works on stable Rust, and requires Rust 1.45+.
+`llvm-ir` works on stable Rust. As of this writing, it requires Rust 1.65+.
 
 ## Development/Debugging
 For development or debugging, you may want LLVM text-format (`*.ll`) files in


### PR DESCRIPTION
Starting in Rust 1.60, this `?` syntax is supported for enabling features of optional dependencies