### PR TITLE
Type size v2

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -1108,12 +1108,12 @@ impl DataLayout {
     /// Port of `llvm::DataLayout::getTypeStoreSize`.
     pub fn get_type_store_size(&self, types: &Types, ty: &Type) -> Option<TypeSize> {
         let base_size = self.get_type_size_in_bits(types, ty)?;
-        fn divide_ceil(numerator: u64, denominator: u64) -> u64 {
+        fn divide_ceil(numerator: u64, denominator: u32) -> u64 {
             let aligned = &Alignment {
-                abi: u32::try_from(denominator).unwrap(),
+                abi: denominator,
                 pref: 0,
             }.align_to_abi(numerator);
-            aligned / denominator
+            aligned / (denominator as u64)
         }
         Some(TypeSize::new(
             divide_ceil(base_size.quantity, 8),

--- a/src/module.rs
+++ b/src/module.rs
@@ -3,7 +3,7 @@ use crate::debugloc::*;
 use crate::function::{Function, FunctionAttribute, FunctionDeclaration, GroupID};
 use crate::llvm_sys::*;
 use crate::name::Name;
-use crate::types::{FPType, Type, TypeRef, Typed, Types, TypesBuilder};
+use crate::types::{FPType, NamedStructDef, Type, TypeRef, Typed, Types, TypesBuilder};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryFrom;
 use std::path::Path;
@@ -1227,7 +1227,11 @@ impl DataLayout {
                 Some(TypeSize::fixed(sz))
             },
             Type::NamedStructType { name } => {
-                self.get_type_size_in_bits(types, &types.named_struct(name))
+                if let Some(NamedStructDef::Defined(def)) = types.named_struct_def(name) {
+                    self.get_type_size_in_bits(types, &def)
+                } else {
+                    None
+                }
             },
             Type::X86_AMXType => Some(TypeSize::fixed(8192)),
             Type::X86_MMXType => Some(TypeSize::fixed(64)),

--- a/src/module.rs
+++ b/src/module.rs
@@ -1108,7 +1108,7 @@ impl DataLayout {
     /// Port of `llvm::DataLayout::getTypeStoreSize`.
     pub fn get_type_store_size(&self, types: &Types, ty: &Type) -> Option<TypeSize> {
         let base_size = self.get_type_size_in_bits(types, ty)?;
-        fn divide_ciel(numerator: u64, denominator: u64) -> u64 {
+        fn divide_ceil(numerator: u64, denominator: u64) -> u64 {
             let aligned = &Alignment {
                 abi: u32::try_from(denominator).unwrap(),
                 pref: 0,
@@ -1116,7 +1116,7 @@ impl DataLayout {
             aligned / denominator
         }
         Some(TypeSize::new(
-            divide_ciel(base_size.quantity, 8),
+            divide_ceil(base_size.quantity, 8),
             base_size.scalable,
         ))
     }

--- a/src/module.rs
+++ b/src/module.rs
@@ -1113,7 +1113,7 @@ impl DataLayout {
                 abi: denominator,
                 pref: 0,
             }.align_to_abi(numerator);
-            aligned / (denominator as u64)
+            1 + aligned / (denominator as u64)
         }
         Some(TypeSize::new(
             divide_ceil(base_size.quantity, 8),

--- a/src/module.rs
+++ b/src/module.rs
@@ -1242,7 +1242,7 @@ impl TypeSize {
         Self::new(quantity, false)
     }
 
-    pub fn min_size(self) -> u64 {
+    pub fn min_size_in_bits(self) -> u64 {
         self.quantity
     }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -1255,9 +1255,17 @@ impl TypeSize {
         Self::new(quantity, false)
     }
 
+    pub fn min_size(self) -> u64 {
+        self.quantity
+    }
+
     fn to_fixed(self) -> u64 {
         assert!(!self.scalable);
         self.quantity
+    }
+
+    pub fn is_fixed(self) -> bool {
+        !self.scalable
     }
 }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -468,6 +468,8 @@ impl Alignments {
                 Type::FuncType { .. } => &self.fptr_alignment_as_alignment,
                 _ => &self.ptr_alignment(*addr_space).alignment,
             },
+            #[cfg(feature = "llvm-16-or-greater")]
+            Type::TargetExtType => todo!(),
             #[cfg(feature = "llvm-15-or-greater")]
             Type::PointerType { addr_space } => &self.ptr_alignment(*addr_space).alignment,
             _ => panic!("Don't know how to get the alignment of {:?}", ty),
@@ -1170,7 +1172,7 @@ impl DataLayout {
             Type::IntegerType { bits } => Some(TypeSize::fixed(u64::from(*bits))),
             Type::PointerType {
                 addr_space,
-                pointee_type: _,
+                ..
             } => self
                 .alignments
                 .pointer_layouts
@@ -1240,6 +1242,7 @@ impl DataLayout {
             Type::MetadataType => None,
             Type::TokenType => None,
             Type::VoidType => None,
+            Type::TargetExtType => todo!(),
         }
     }
 }


### PR DESCRIPTION
This pull requests continues the work of @langston-barrett in #34 . I have taken into account the concerns you expressed in that pull request and rebased it to the current main branch.

I was not able to to address this concern:
[Can we have a comment pointing to the upstream function this is a port of, similar to how you did for getTypeSizeInBits?](https://github.com/cdisselkoen/llvm-ir/pull/34#discussion_r1103872088) as I am not sure if this function is equivalent to the llvm function I have been able to  identify (https://llvm.org/doxygen/DataLayout_8cpp_source.html#l00553).

And I would like feedback on how to deal with Type::TargetExtType as we don't have access to the type's data as explained in the enum.

I am no expert on llvm so any feedback is appreciated. 

As a last note, I've seen the confusion between bits and bites multiple times in the code (I've hopefully fixed them), but upon successful validation of this code, a bit and byte types should be created moving forward.