### PR TITLE
LLVM 19.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llvm-ir"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["Craig Disselkoen <craigdissel@gmail.com>"]
 edition = "2018"
 description = "LLVM IR in natural Rust data structures"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ llvm-sys-150 = { package = "llvm-sys", version = "150.1.0", optional = true }
 llvm-sys-160 = { package = "llvm-sys", version = "160.1.2", optional = true }
 llvm-sys-170 = { package = "llvm-sys", version = "170.0.1", optional = true }
 llvm-sys-181 = { package = "llvm-sys", version = "181.0.0", optional = true }
+llvm-sys-191 = { package = "llvm-sys", version = "191.0.0", optional = true }
 either = "1.9"
 log = "0.4"
 
@@ -42,6 +43,7 @@ llvm-15 = ["llvm-sys-150", "llvm-15-or-lower", "llvm-15-or-greater"]
 llvm-16 = ["llvm-sys-160", "llvm-16-or-lower", "llvm-16-or-greater"]
 llvm-17 = ["llvm-sys-170", "llvm-17-or-lower", "llvm-17-or-greater"]
 llvm-18 = ["llvm-sys-181", "llvm-18-or-lower", "llvm-18-or-greater"]
+llvm-19 = ["llvm-sys-191", "llvm-19-or-lower", "llvm-19-or-greater"]
 
 ###
 # For convenience, these automatically-enabled features allow us to avoid
@@ -57,6 +59,7 @@ llvm-15-or-greater = ["llvm-14-or-greater"]
 llvm-16-or-greater = ["llvm-15-or-greater"]
 llvm-17-or-greater = ["llvm-16-or-greater"]
 llvm-18-or-greater = ["llvm-17-or-greater"]
+llvm-19-or-greater = ["llvm-18-or-greater"]
 
 llvm-9-or-lower = ["llvm-10-or-lower"]
 llvm-10-or-lower = ["llvm-11-or-lower"]
@@ -67,7 +70,8 @@ llvm-14-or-lower = ["llvm-15-or-lower"]
 llvm-15-or-lower = ["llvm-16-or-lower"]
 llvm-16-or-lower = ["llvm-17-or-lower"]
 llvm-17-or-lower = ["llvm-18-or-lower"]
-llvm-18-or-lower = []
+llvm-18-or-lower = ["llvm-19-or-lower"]
+llvm-19-or-lower = []
 ###
 
 # The `strict-versioning` feature requires an exact match between the
@@ -88,6 +92,7 @@ strict-versioning = [
     "llvm-sys-160?/strict-versioning",
     "llvm-sys-170?/strict-versioning",
     "llvm-sys-181?/strict-versioning",
+    "llvm-sys-191?/strict-versioning",
 ]
 
 # The `prefer-dynamic` feature is only available on llvm-sys versions >= 120.
@@ -99,6 +104,7 @@ prefer-dynamic = [
     "llvm-sys-160?/prefer-dynamic",
     "llvm-sys-170?/prefer-dynamic",
     "llvm-sys-181?/prefer-dynamic",
+    "llvm-sys-191?/prefer-dynamic",
 ]
 
 [package.metadata.docs.rs]

--- a/build.rs
+++ b/build.rs
@@ -30,6 +30,9 @@ fn main() {
     if cfg!(feature = "llvm-18") {
         versions.push(18);
     }
+    if cfg!(feature = "llvm-19") {
+        versions.push(19);
+    }
     match versions.len() {
         0 => panic!("llvm-ir: Please select an LLVM version using a Cargo feature."),
         1 => {},

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -81,6 +81,7 @@ pub enum Constant {
     #[cfg(feature = "llvm-17-or-lower")]
     Or(Or),
     Xor(Xor),
+    #[cfg(feature = "llvm-18-or-lower")]
     Shl(Shl),
     #[cfg(feature = "llvm-17-or-lower")]
     LShr(LShr),
@@ -137,7 +138,9 @@ pub enum Constant {
     AddrSpaceCast(AddrSpaceCast),
 
     // Other ops
+    #[cfg(feature = "llvm-18-or-lower")]
     ICmp(ICmp),
+    #[cfg(feature = "llvm-18-or-lower")]
     FCmp(FCmp),
     #[cfg(feature = "llvm-16-or-lower")]
     Select(Select),
@@ -242,6 +245,7 @@ impl Typed for Constant {
             #[cfg(feature = "llvm-17-or-lower")]
             Constant::Or(o) => types.type_of(o),
             Constant::Xor(x) => types.type_of(x),
+            #[cfg(feature = "llvm-18-or-lower")]
             Constant::Shl(s) => types.type_of(s),
             #[cfg(feature = "llvm-17-or-lower")]
             Constant::LShr(l) => types.type_of(l),
@@ -286,7 +290,9 @@ impl Typed for Constant {
             Constant::IntToPtr(i) => types.type_of(i),
             Constant::BitCast(b) => types.type_of(b),
             Constant::AddrSpaceCast(a) => types.type_of(a),
+            #[cfg(feature = "llvm-18-or-lower")]
             Constant::ICmp(i) => types.type_of(i),
+            #[cfg(feature = "llvm-18-or-lower")]
             Constant::FCmp(f) => types.type_of(f),
             #[cfg(feature="llvm-16-or-lower")]
             Constant::Select(s) => types.type_of(s),
@@ -423,6 +429,7 @@ impl Display for Constant {
             #[cfg(feature = "llvm-17-or-lower")]
             Constant::Or(o) => write!(f, "{}", o),
             Constant::Xor(x) => write!(f, "{}", x),
+            #[cfg(feature = "llvm-18-or-lower")]
             Constant::Shl(s) => write!(f, "{}", s),
             #[cfg(feature = "llvm-17-or-lower")]
             Constant::LShr(l) => write!(f, "{}", l),
@@ -467,9 +474,11 @@ impl Display for Constant {
             Constant::IntToPtr(i) => write!(f, "{}", i),
             Constant::BitCast(b) => write!(f, "{}", b),
             Constant::AddrSpaceCast(a) => write!(f, "{}", a),
+            #[cfg(feature = "llvm-18-or-lower")]
             Constant::ICmp(i) => write!(f, "{}", i),
+            #[cfg(feature = "llvm-18-or-lower")]
             Constant::FCmp(c) => write!(f, "{}", c),
-            #[cfg(feature="llvm-16-or-lower")]
+            #[cfg(feature = "llvm-16-or-lower")]
             Constant::Select(s) => write!(f, "{}", s),
         }
     }
@@ -763,6 +772,7 @@ pub struct Xor {
 impl_constexpr!(Xor, Xor);
 binop_same_type!(Xor, "xor");
 
+#[cfg(feature = "llvm-18-or-lower")]
 #[derive(PartialEq, Clone, Debug)]
 pub struct Shl {
     pub operand0: ConstantRef,
@@ -771,7 +781,9 @@ pub struct Shl {
     // pub nuw: bool,  // getters for these seem to not be exposed in the LLVM C API, only in the C++ one
 }
 
+#[cfg(feature = "llvm-18-or-lower")]
 impl_constexpr!(Shl, Shl);
+#[cfg(feature = "llvm-18-or-lower")]
 binop_left_type!(Shl, "shl");
 
 #[cfg(feature = "llvm-17-or-lower")]
@@ -1260,6 +1272,7 @@ pub struct AddrSpaceCast {
 impl_constexpr!(AddrSpaceCast, AddrSpaceCast);
 unop_explicitly_typed!(AddrSpaceCast, "addrspacecast");
 
+#[cfg(feature = "llvm-18-or-lower")]
 #[derive(PartialEq, Clone, Debug)]
 pub struct ICmp {
     pub predicate: IntPredicate,
@@ -1267,9 +1280,12 @@ pub struct ICmp {
     pub operand1: ConstantRef,
 }
 
+#[cfg(feature = "llvm-18-or-lower")]
 impl_constexpr!(ICmp, ICmp);
+#[cfg(feature = "llvm-18-or-lower")]
 impl_binop!(ICmp, "icmp");
 
+#[cfg(feature = "llvm-18-or-lower")]
 impl Typed for ICmp {
     fn get_type(&self, types: &Types) -> TypeRef {
         let ty = types.type_of(&self.operand0);
@@ -1288,6 +1304,7 @@ impl Typed for ICmp {
     }
 }
 
+#[cfg(feature = "llvm-18-or-lower")]
 impl Display for ICmp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
@@ -1298,6 +1315,7 @@ impl Display for ICmp {
     }
 }
 
+#[cfg(feature = "llvm-18-or-lower")]
 #[derive(PartialEq, Clone, Debug)]
 pub struct FCmp {
     pub predicate: FPPredicate,
@@ -1305,9 +1323,12 @@ pub struct FCmp {
     pub operand1: ConstantRef,
 }
 
+#[cfg(feature = "llvm-18-or-lower")]
 impl_constexpr!(FCmp, FCmp);
+#[cfg(feature = "llvm-18-or-lower")]
 impl_binop!(FCmp, "fcmp");
 
+#[cfg(feature = "llvm-18-or-lower")]
 impl Typed for FCmp {
     fn get_type(&self, types: &Types) -> TypeRef {
         let ty = types.type_of(&self.operand0);
@@ -1326,6 +1347,7 @@ impl Typed for FCmp {
     }
 }
 
+#[cfg(feature = "llvm-18-or-lower")]
 impl Display for FCmp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
@@ -1537,6 +1559,7 @@ impl Constant {
                     #[cfg(feature = "llvm-17-or-lower")]
                     LLVMOpcode::LLVMOr => Constant::Or(Or::from_llvm_ref(constant, ctx)),
                     LLVMOpcode::LLVMXor => Constant::Xor(Xor::from_llvm_ref(constant, ctx)),
+                    #[cfg(feature = "llvm-18-or-lower")]
                     LLVMOpcode::LLVMShl => Constant::Shl(Shl::from_llvm_ref(constant, ctx)),
                     #[cfg(feature = "llvm-17-or-lower")]
                     LLVMOpcode::LLVMLShr => Constant::LShr(LShr::from_llvm_ref(constant, ctx)),
@@ -1581,7 +1604,9 @@ impl Constant {
                     LLVMOpcode::LLVMIntToPtr => Constant::IntToPtr(IntToPtr::from_llvm_ref(constant, ctx)),
                     LLVMOpcode::LLVMBitCast => Constant::BitCast(BitCast::from_llvm_ref(constant, ctx)),
                     LLVMOpcode::LLVMAddrSpaceCast => Constant::AddrSpaceCast(AddrSpaceCast::from_llvm_ref(constant, ctx)),
+                    #[cfg(feature = "llvm-18-or-lower")]
                     LLVMOpcode::LLVMICmp => Constant::ICmp(ICmp::from_llvm_ref(constant, ctx)),
+                    #[cfg(feature = "llvm-18-or-lower")]
                     LLVMOpcode::LLVMFCmp => Constant::FCmp(FCmp::from_llvm_ref(constant, ctx)),
                     #[cfg(feature="llvm-16-or-lower")]
                     LLVMOpcode::LLVMSelect => Constant::Select(Select::from_llvm_ref(constant, ctx)),
@@ -1631,6 +1656,7 @@ binop_from_llvm!(And);
 #[cfg(feature = "llvm-17-or-lower")]
 binop_from_llvm!(Or);
 binop_from_llvm!(Xor);
+#[cfg(feature = "llvm-18-or-lower")]
 binop_from_llvm!(Shl);
 #[cfg(feature = "llvm-17-or-lower")]
 binop_from_llvm!(LShr);
@@ -1772,6 +1798,7 @@ typed_unop_from_llvm!(IntToPtr);
 typed_unop_from_llvm!(BitCast);
 typed_unop_from_llvm!(AddrSpaceCast);
 
+#[cfg(feature = "llvm-18-or-lower")]
 impl ICmp {
     pub(crate) fn from_llvm_ref(expr: LLVMValueRef, ctx: &mut ModuleContext) -> Self {
         assert_eq!(unsafe { LLVMGetNumOperands(expr) }, 2);
@@ -1783,6 +1810,7 @@ impl ICmp {
     }
 }
 
+#[cfg(feature = "llvm-18-or-lower")]
 impl FCmp {
     pub(crate) fn from_llvm_ref(expr: LLVMValueRef, ctx: &mut ModuleContext) -> Self {
         assert_eq!(unsafe { LLVMGetNumOperands(expr) }, 2);

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -3481,6 +3481,10 @@ impl RMWBinOp {
             LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFMax => Self::FMax,
             #[cfg(feature = "llvm-15-or-greater")]
             LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFMin => Self::FMin,
+            #[cfg(feature = "llvm-19-or-greater")]
+            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUIncWrap => todo!(),
+            #[cfg(feature = "llvm-19-or-greater")]
+            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUDecWrap => todo!()
         }
     }
 }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -2448,6 +2448,10 @@ pub enum RMWBinOp {
     FMax,
     #[cfg(feature = "llvm-15-or-greater")]
     FMin,
+    #[cfg(feature = "llvm-19-or-greater")]
+    UIncWrap,
+    #[cfg(feature = "llvm-19-or-greater")]
+    UDecWrap
 }
 
 impl Display for RMWBinOp {
@@ -2472,6 +2476,10 @@ impl Display for RMWBinOp {
             Self::FMax => write!(f, "fmax"),
             #[cfg(feature = "llvm-15-or-greater")]
             Self::FMin => write!(f, "fmin"),
+            #[cfg(feature = "llvm-19-or-greater")]
+            Self::UIncWrap => write!(f, "uinc_wrap"),
+            #[cfg(feature = "llvm-19-or-greater")]
+            Self::UDecWrap => write!(f, "udec_wrap"),
         }
     }
 }
@@ -3482,9 +3490,9 @@ impl RMWBinOp {
             #[cfg(feature = "llvm-15-or-greater")]
             LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFMin => Self::FMin,
             #[cfg(feature = "llvm-19-or-greater")]
-            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUIncWrap => todo!(),
+            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUIncWrap => Self::UIncWrap,
             #[cfg(feature = "llvm-19-or-greater")]
-            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUDecWrap => todo!()
+            LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUDecWrap => Self::UDecWrap
         }
     }
 }

--- a/src/llvm_sys.rs
+++ b/src/llvm_sys.rs
@@ -16,6 +16,8 @@ pub use llvm_sys_160 as llvm_sys;
 pub use llvm_sys_170 as llvm_sys;
 #[cfg(feature = "llvm-18")]
 pub use llvm_sys_181 as llvm_sys;
+#[cfg(feature = "llvm-19")]
+pub use llvm_sys_191 as llvm_sys;
 #[cfg(feature = "llvm-9")]
 pub use llvm_sys_90 as llvm_sys;
 


### PR DESCRIPTION
This PR attempts to add LLVM 19.1.0 support.

### Added conditional compilation features.
The `llvm-19`, `llvm-19-or-greater`, and `llvm-19-or-lower` features were added.

### Removed constant expressions:
According to https://releases.llvm.org/19.1.0/docs/ReleaseNotes.html#changes-to-the-llvm-ir, the constant expressions `icmp`, `fcmp`, and `shl` were removed. `llvm-sys` reflects this, removing the `LLVMICmp`, `LLVMFCmp`, and `LLVMShl` variants from the `LLVMOpcode` enum.
The corresponding variants on the `Constant` enum as well as the related structs and impls in `llvm-ir` have been placed behind `#[cfg(feature = "llvm-18-or-lower")]`.

### Added binary atomic operations:
`llvm-sys` added variants `LLVMAtomicRMWBinOpUIncWrap` and `LLVMAtomicRMWBinOpUDecWrap` to the `LLVMAtomicRMWBinOp` enum.
Variants `UIncWrap` and `UDecWrap` have been added to the `RMWBinOp` enum in `llvm-ir`. Their `Display` outputs are `uinc_wrap` and `udec_wrap`, which can be found at https://releases.llvm.org/19.1.0/docs/LangRef.html#atomicrmw-instruction.

### Pointer Authentication:
The [LLVM 19.1.0 release notes](https://releases.llvm.org/19.1.0/docs/ReleaseNotes.html#changes-to-the-llvm-ir) mentions the addition of [pointer authentication constants](https://releases.llvm.org/19.1.0/docs/LangRef.html#pointer-authentication-constants) and [pointer authentication operand bundles](https://releases.llvm.org/19.1.0/docs/LangRef.html#pointer-authentication-operand-bundles). However, `llvm-sys` doesn't seem to have added anything for it to the `LLVMValueKind` enum. Thus, I have skipped it for now. [`LLVMIsAConstantPtrAuth`](https://docs.rs/llvm-sys/191.0.0/llvm_sys/core/fn.LLVMIsAConstantPtrAuth.html), [`LLVMGetConstantPtrAuthKey`](https://docs.rs/llvm-sys/191.0.0/llvm_sys/core/fn.LLVMGetConstantPtrAuthKey.html), [`LLVMGetConstantPtrAuthPointer`](https://docs.rs/llvm-sys/191.0.0/llvm_sys/core/fn.LLVMGetConstantPtrAuthPointer.html), [`LLVMGetConstantPtrAuthDiscriminator`](https://docs.rs/llvm-sys/191.0.0/llvm_sys/core/fn.LLVMGetConstantPtrAuthDiscriminator.html), and [`LLVMGetConstantPtrAuthAddrDiscriminator`](https://docs.rs/llvm-sys/191.0.0/llvm_sys/core/fn.LLVMGetConstantPtrAuthAddrDiscriminator.html) may be worth looking at later.

### Changed package version
The package version of `llvm-ir` has been changed from `0.11.1` to `0.12.0`.