### PR TITLE
Use LLVMCreateMemoryBufferWithMemoryRangeCopy to avoid unsoundness in string conversions

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -103,14 +103,13 @@ impl Module {
         Self::from_path(path, Self::parse_ir)
     }
 
-    /// Parse the given string as LLVM text IR to create a `Module`
+    /// Parse the given string as LLVM text IR by copying to create a `Module`
     pub fn from_ir_str(str: &str) -> Result<Self, String> {
         let memory_buffer = unsafe {
-            LLVMCreateMemoryBufferWithMemoryRange(
+            LLVMCreateMemoryBufferWithMemoryRangeCopy(
                 str.as_ptr() as *const _,
                 str.len(),
-                std::ffi::CString::new("str").unwrap().as_ptr(),
-                true.into(),
+                std::ffi::CString::default().as_ptr(),
             )
         };
         Self::from_buffer(memory_buffer, Self::parse_ir)
@@ -126,7 +125,7 @@ impl Module {
         // This call takes ownership of the buffer, so we don't free it.
         match llvm_sys::ir_reader::LLVMParseIRInContext(context_ref, mem_buf, out_module, &mut err_string) {
             0 => Ok(()),
-            _ => Err(format!("Failed to parse bitcode: {}",
+            _ => Err(format!("Failed to parse IR: {}",
                              CStr::from_ptr(err_string).to_str().expect("Failed to convert CStr")))
         }
     }


### PR DESCRIPTION
Continuation from #66

It seems like there is no way to take a `&str` and make a LLVM Memory Buffer from it without copying, as all LLVM Memory Buffers are built from null-terminated strings (despite the misleading `RequiresNullTerminator` argument) and there is no such guarantee for an arbitrary `&str`. I've changed the function call to copy in the string instead, which handles this conversion, and add a test also.

Related:
https://github.com/TheDan64/inkwell/issues/516
https://github.com/TheDan64/inkwell/issues/185