### PR TITLE
lib: add missing llvm-19 case

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,5 +56,6 @@ pub fn llvm_version() -> &'static str {
     case!("llvm-16");
     case!("llvm-17");
     case!("llvm-18");
+    case!("llvm-19");
     unreachable!()
 }


### PR DESCRIPTION
Hello again!

LLVM 19 support was mostly added with https://github.com/cdisselkoen/llvm-ir/pull/64, but this `case!` declaration was missing. I've gone ahead and added it!

xref: https://github.com/trailofbits/siderophile/pull/276