### PR TITLE
Add the value type for GlobalVariable

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -207,6 +207,7 @@ pub struct GlobalVariable {
     pub comdat: Option<Comdat>, // llvm-hs-pure has Option<String> for some reason
     pub alignment: u32,
     pub debugloc: Option<DebugLoc>,
+    pub value_type: TypeRef
     // --TODO not yet implemented-- pub metadata: Vec<(String, MetadataRef<MetadataNode>)>,
 }
 
@@ -693,6 +694,7 @@ impl GlobalVariable {
         ctx: &mut ModuleContext,
     ) -> Self {
         let ty = ctx.types.type_from_llvm_ref(unsafe { LLVMTypeOf(global) });
+        let value_type = ctx.types.type_from_llvm_ref(unsafe { LLVMGlobalGetValueType(global) });
         let addr_space = match ty.as_ref() {
             Type::PointerType { addr_space, .. } => *addr_space,
             _ => panic!("GlobalVariable has a non-pointer type, {:?}", ty),
@@ -731,6 +733,7 @@ impl GlobalVariable {
             },
             alignment: unsafe { LLVMGetAlignment(global) },
             debugloc: DebugLoc::from_llvm_no_col(global),
+            value_type,
             // metadata: unimplemented!("metadata"),
         }
     }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -1503,6 +1503,7 @@ fn variablesbc() {
     assert_eq!(var.ty, module.types.pointer_to(module.types.i32()));
     #[cfg(feature = "llvm-15-or-greater")]
     assert_eq!(var.ty, module.types.pointer());
+    assert_eq!(var.value_type, module.types.i32());
     assert_eq!(
         var.initializer,
         Some(ConstantRef::new(Constant::Int { bits: 32, value: 5 }))


### PR DESCRIPTION
`GlobalVariable::ty` is just its pointer, so if there's no initializer there doesn't seem to be a way to get the type of the variable's value itself

Includes a new test on the `variables.bc` bitcode file