### PR TITLE
Update the Ubuntu image for CI jobs to 24.04 since the old one is deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     name: Test for LLVM ${{ matrix.llvm }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
See this announcement, the 20.04 runners no longer run https://github.com/actions/runner-images/issues/11101