### PR TITLE
Use github action action for LLVM 18 and below, and apt packages for 19+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,31 @@ jobs:
       - name: Install libtinfo
         run: sudo apt-get update && sudo apt-get install -y libtinfo5
 
-      - name: Install LLVM ${{ matrix.llvm }}
+      - name: Install LLVM ${{ matrix.llvm }} (via Github Action)
         uses: KyleMayes/install-llvm-action@v2
         with:
           version: ${{ matrix.llvm }}
+        if: matrix.llvm < 19
+
+      # As of LLVM 19, the official LLVM binaries (which the install-llvm-action action uses), are built with LTO enabled
+      # To avoid breaking on non-LLVM linkers in CI, we can install the official apt binaries for LLVM 19 and above
+      - name: Install LLVM ${{ matrix.llvm }} (via official install script)
+        if: matrix.llvm >= 19
+        run: curl https://apt.llvm.org/llvm.sh | sudo bash  -s -- ${{ matrix.llvm }}
+
+      # Polly only needs explicit installation if we are installing LLVM via the apt packages
+      - name: Install Polly ${{ matrix.llvm }}
+        run: sudo apt-get install -y libpolly-${{ matrix.llvm }}-dev
+        if: matrix.llvm >= 19
 
       - name: llvm-config
         run: llvm-config --version --bindir --libdir
+        if: matrix.llvm < 19
+
+      # The apt packages install with a version suffix
+      - name: llvm-config
+        run: llvm-config-${{ matrix.llvm }} --version --bindir --libdir
+        if: matrix.llvm >= 19
 
       - name: Install zstd
         run: sudo apt-get install -y libzstd-dev


### PR DESCRIPTION
Use the install-llvm-action action for LLVM version 18 and below, and the official apt packages for 19 and above

https://github.com/KyleMayes/install-llvm-action uses the semi-official binaries uploaded to the LLVM github releases. For LLVM 19, these are built with LTO, which cannot be linked against by the standard linkers (and broke CI for LLVM 19).

To work around this, we can use the github action to install older versions of LLVM, but use the official apt packages for newer versions. Ubuntu 24.04 (noble) has packages starting at LLVM 17, so this should be good for a while.

This is pretty much what Inkwell seems to be doing as well: https://github.com/TheDan64/inkwell/pull/557