### PR TITLE
Optimize memory usage for filenames and directories in debug locations

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -428,7 +428,7 @@ impl FunctionDeclaration {
             }),
             alignment: unsafe { LLVMGetAlignment(func) },
             garbage_collector_name: unsafe { get_gc(func) },
-            debugloc: DebugLoc::from_llvm_no_col(func),
+            debugloc: DebugLoc::from_llvm_no_col(func, &mut ctx.string_interner),
         };
         (decl, local_ctr)
     }

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,5 +1,6 @@
 use crate::constant::ConstantRef;
 use crate::debugloc::*;
+use crate::from_llvm::StringInterner;
 use crate::function::{Function, FunctionAttribute, FunctionDeclaration, GroupID};
 use crate::llvm_sys::*;
 use crate::name::Name;
@@ -611,6 +612,8 @@ pub(crate) struct ModuleContext<'a> {
     // We use LLVMValueRef as a *const, even though it's technically a *mut
     #[allow(clippy::mutable_key_type)]
     pub global_names: &'a HashMap<LLVMValueRef, Name>,
+    /// String interner for debug location filenames and directories
+    pub string_interner: StringInterner,
 }
 
 impl<'a> ModuleContext<'a> {
@@ -622,6 +625,7 @@ impl<'a> ModuleContext<'a> {
             attrsdata: AttributesData::create(),
             constants: HashMap::new(),
             global_names,
+            string_interner: StringInterner::new(),
         }
     }
 }
@@ -730,7 +734,7 @@ impl GlobalVariable {
                 }
             },
             alignment: unsafe { LLVMGetAlignment(global) },
-            debugloc: DebugLoc::from_llvm_no_col(global),
+            debugloc: DebugLoc::from_llvm_no_col(global, &mut ctx.string_interner),
             // metadata: unimplemented!("metadata"),
         }
     }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -153,7 +153,7 @@ fn hellobcg() {
         .expect("Expected main() to have a debugloc");
     assert_eq!(debugloc.line, 3);
     assert_eq!(debugloc.col, None);
-    assert_eq!(debugloc.filename, debug_filename);
+    assert_eq!(debugloc.filename.as_str(), debug_filename);
     assert!(debugloc.directory.as_ref().expect("directory should exist").ends_with(debug_directory_suffix));
 
     let bb = &func.basic_blocks[0];
@@ -168,7 +168,7 @@ fn hellobcg() {
         .expect("expected the Ret to have a debugloc");
     assert_eq!(debugloc.line, 4);
     assert_eq!(debugloc.col, Some(3));
-    assert_eq!(debugloc.filename, debug_filename);
+    assert_eq!(debugloc.filename.as_str(), debug_filename);
     assert!(debugloc.directory.as_ref().expect("directory should exist").ends_with(debug_directory_suffix));
     assert_eq!(&ret.to_string(), "ret i32 0 (with debugloc)");
 }
@@ -1639,7 +1639,7 @@ fn variablesbcg() {
         .expect("expected the global to have a debugloc");
     assert_eq!(debugloc.line, 5);
     assert_eq!(debugloc.col, None); // only `Instruction`s and `Terminator`s get column numbers
-    assert_eq!(debugloc.filename, debug_filename);
+    assert_eq!(debugloc.filename.as_str(), debug_filename);
     assert!(debugloc.directory.as_ref().expect("directory should exist").ends_with(debug_directory_suffix));
 }
 
@@ -1939,7 +1939,7 @@ fn rustbcg() {
         .expect("Expected function to have a debugloc");
     assert_eq!(debugloc.line, 3);
     assert_eq!(debugloc.col, None);
-    assert_eq!(debugloc.filename, debug_filename);
+    assert_eq!(debugloc.filename.as_str(), debug_filename);
     assert!(debugloc.directory.as_ref().expect("directory should exist").ends_with(debug_directory_suffix));
 
     let startbb = func
@@ -1967,7 +1967,7 @@ fn rustbcg() {
         .expect("Expected this store to have a debugloc");
     assert_eq!(store_debugloc.line, 4);
     assert_eq!(store_debugloc.col, Some(18));
-    assert_eq!(store_debugloc.filename, debug_filename);
+    assert_eq!(store_debugloc.filename.as_str(), debug_filename);
     assert!(debugloc.directory.as_ref().expect("directory should exist").ends_with(debug_directory_suffix));
     #[cfg(feature = "llvm-14-or-lower")]
     let expected_fmt = "store i64 0, i64* %sum, align 8 (with debugloc)";
@@ -1980,7 +1980,7 @@ fn rustbcg() {
         .expect("Expected this call to have a debugloc");
     assert_eq!(call_debugloc.line, 5);
     assert_eq!(call_debugloc.col, Some(13));
-    assert_eq!(call_debugloc.filename, debug_filename);
+    assert_eq!(call_debugloc.filename.as_str(), debug_filename);
     assert!(debugloc.directory.as_ref().expect("directory should exist").ends_with(debug_directory_suffix));
     #[cfg(feature = "llvm-14-or-lower")]
     let expected_fmt = "%4 = call @_ZN68_$LT$alloc..vec..Vec$LT$T$GT$$u20$as$u20$core..ops..deref..Deref$GT$5deref17h378128d7d9378466E(%alloc::vec::Vec<isize>* %3) (with debugloc)";
@@ -2136,7 +2136,7 @@ fn simple_linked_list_g() {
         .expect("expected simple_linked_list to have a debugloc");
     assert_eq!(debugloc.line, 8);
     assert_eq!(debugloc.col, None);
-    assert_eq!(debugloc.filename, debug_filename);
+    assert_eq!(debugloc.filename.as_str(), debug_filename);
     assert!(debugloc.directory.as_ref().expect("directory should exist").ends_with(debug_directory_suffix));
 
     // the first seven instructions shouldn't have debuglocs - they are just setting up the stack frame
@@ -2154,7 +2154,7 @@ fn simple_linked_list_g() {
             .expect("expected this instruction to have a debugloc");
         assert_eq!(debugloc.line, 8);
         assert_eq!(debugloc.col, Some(28));
-        assert_eq!(debugloc.filename, debug_filename);
+        assert_eq!(debugloc.filename.as_str(), debug_filename);
         assert!(debugloc.directory.as_ref().expect("directory should exist").ends_with(debug_directory_suffix));
         assert_eq!(
             &func.basic_blocks[0].instrs[7].to_string(),
@@ -2169,7 +2169,7 @@ fn simple_linked_list_g() {
         .expect("expected this instruction to have a debugloc");
     assert_eq!(debugloc.line, 9);
     assert_eq!(debugloc.col, Some(34));
-    assert_eq!(debugloc.filename, debug_filename);
+    assert_eq!(debugloc.filename.as_str(), debug_filename);
     assert!(debugloc.directory.as_ref().expect("directory should exist").ends_with(debug_directory_suffix));
 
     #[cfg(feature = "llvm-14-or-lower")]


### PR DESCRIPTION
Hello,

I noticed that each instruction stores a DebugLoc, which itself stores a filename and directory as a String.
Most of the time, the filename and directory will be the same for a given function definition.
This means we are wasting a lot of memory storing the filename N times with N being the number of instructions with debug information.

This pull request proposes to use string interning with `Arc<String>` to store filenames and directories in debug locations. The string interner is created once when parsing a given LLVM bitcode file. We could even use a string interning crate, but I think this is a good first step.

The only downside is that this requires a change in the API, each user of debug location will now need to call `filename.as_str()`. Is this considered a blocker? Can we simply increase the version of the package?

If this is accepted, I think we could do the same for `name::Name` and replace `Box<String>` with `Arc<String>`, to avoid storing a fully allocated string for the register names of each instruction.