### PR TITLE
Implement Display trait for all types to produce valid LLVM IR text

### DIFF
--- a/src/basicblock.rs
+++ b/src/basicblock.rs
@@ -12,6 +12,21 @@ pub struct BasicBlock {
     pub term: Terminator,
 }
 
+impl std::fmt::Display for BasicBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        // label: the name without the % prefix
+        match &self.name {
+            Name::Name(n) => writeln!(f, "{}:", n)?,
+            Name::Number(n) => writeln!(f, "{}:", n)?,
+        }
+        for instr in &self.instrs {
+            writeln!(f, "  {}", instr)?;
+        }
+        writeln!(f, "  {}", self.term)?;
+        Ok(())
+    }
+}
+
 impl BasicBlock {
     /// A `BasicBlock` instance with no instructions and an `Unreachable` terminator
     pub fn new(name: Name) -> Self {

--- a/src/function.rs
+++ b/src/function.rs
@@ -2,6 +2,7 @@ use crate::debugloc::{DebugLoc, HasDebugLoc};
 use crate::module::{Comdat, DLLStorageClass, Linkage, Visibility};
 use crate::types::{TypeRef, Typed, Types};
 use crate::{BasicBlock, ConstantRef, Name};
+use std::fmt::{self, Display};
 
 /// See [LLVM 14 docs on Functions](https://releases.llvm.org/14.0.0/docs/LangRef.html#functions)
 #[derive(PartialEq, Clone, Debug, Hash)]
@@ -298,6 +299,358 @@ pub enum ParameterAttribute {
 }
 
 pub type GroupID = usize;
+
+// ======= //
+// Display  //
+// ======= //
+
+impl Display for CallingConvention {
+    #[rustfmt::skip]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CallingConvention::C => Ok(()), // ccc is the default, omit it
+            CallingConvention::Fast => write!(f, "fastcc"),
+            CallingConvention::Cold => write!(f, "coldcc"),
+            CallingConvention::GHC => write!(f, "ghccc"),
+            CallingConvention::HiPE => write!(f, "cc 11"),
+            CallingConvention::WebKit_JS => write!(f, "webkit_jscc"),
+            CallingConvention::AnyReg => write!(f, "anyregcc"),
+            CallingConvention::PreserveMost => write!(f, "preserve_mostcc"),
+            CallingConvention::PreserveAll => write!(f, "preserve_allcc"),
+            CallingConvention::Swift => write!(f, "swiftcc"),
+            CallingConvention::CXX_FastTLS => write!(f, "cxx_fast_tlscc"),
+            CallingConvention::X86_StdCall => write!(f, "x86_stdcallcc"),
+            CallingConvention::X86_FastCall => write!(f, "x86_fastcallcc"),
+            CallingConvention::X86_RegCall => write!(f, "x86_regcallcc"),
+            CallingConvention::X86_ThisCall => write!(f, "x86_thiscallcc"),
+            CallingConvention::X86_VectorCall => write!(f, "x86_vectorcallcc"),
+            CallingConvention::X86_Intr => write!(f, "x86_intrcc"),
+            CallingConvention::X86_64_SysV => write!(f, "x86_64_sysvcc"),
+            CallingConvention::ARM_APCS => write!(f, "arm_apcscc"),
+            CallingConvention::ARM_AAPCS => write!(f, "arm_aapcscc"),
+            CallingConvention::ARM_AAPCS_VFP => write!(f, "arm_aapcs_vfpcc"),
+            CallingConvention::MSP430_INTR => write!(f, "msp430_intrcc"),
+            CallingConvention::MSP430_Builtin => write!(f, "cc 78"),
+            CallingConvention::PTX_Kernel => write!(f, "ptx_kernel"),
+            CallingConvention::PTX_Device => write!(f, "ptx_device"),
+            CallingConvention::SPIR_FUNC => write!(f, "spir_func"),
+            CallingConvention::SPIR_KERNEL => write!(f, "spir_kernel"),
+            CallingConvention::Intel_OCL_BI => write!(f, "intel_ocl_bicc"),
+            CallingConvention::Win64 => write!(f, "win64cc"),
+            CallingConvention::HHVM => write!(f, "hhvmcc"),
+            CallingConvention::HHVM_C => write!(f, "hhvm_ccc"),
+            CallingConvention::AVR_Intr => write!(f, "avr_intrcc"),
+            CallingConvention::AVR_Signal => write!(f, "avr_signalcc"),
+            CallingConvention::AVR_Builtin => write!(f, "cc 86"),
+            CallingConvention::AMDGPU_CS => write!(f, "amdgpu_cs"),
+            CallingConvention::AMDGPU_ES => write!(f, "amdgpu_es"),
+            CallingConvention::AMDGPU_GS => write!(f, "amdgpu_gs"),
+            CallingConvention::AMDGPU_HS => write!(f, "amdgpu_hs"),
+            CallingConvention::AMDGPU_LS => write!(f, "amdgpu_ls"),
+            CallingConvention::AMDGPU_PS => write!(f, "amdgpu_ps"),
+            CallingConvention::AMDGPU_VS => write!(f, "amdgpu_vs"),
+            CallingConvention::AMDGPU_Kernel => write!(f, "amdgpu_kernel"),
+            CallingConvention::Numbered(n) => write!(f, "cc {}", n),
+        }
+    }
+}
+
+impl Display for MemoryEffect {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            MemoryEffect::None => write!(f, "none"),
+            MemoryEffect::Read => write!(f, "read"),
+            MemoryEffect::Write => write!(f, "write"),
+            MemoryEffect::ReadWrite => write!(f, "readwrite"),
+        }
+    }
+}
+
+impl Display for FunctionAttribute {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            FunctionAttribute::AlignStack(n) => write!(f, "alignstack({})", n),
+            FunctionAttribute::AllocSize { elt_size, num_elts } => {
+                write!(f, "allocsize({}",  elt_size)?;
+                if let Some(n) = num_elts {
+                    write!(f, ", {}", n)?;
+                }
+                write!(f, ")")
+            },
+            FunctionAttribute::AlwaysInline => write!(f, "alwaysinline"),
+            FunctionAttribute::Builtin => write!(f, "builtin"),
+            FunctionAttribute::Cold => write!(f, "cold"),
+            FunctionAttribute::Convergent => write!(f, "convergent"),
+            FunctionAttribute::InaccessibleMemOnly => write!(f, "inaccessiblememonly"),
+            FunctionAttribute::InaccessibleMemOrArgMemOnly => write!(f, "inaccessiblemem_or_argmemonly"),
+            FunctionAttribute::InlineHint => write!(f, "inlinehint"),
+            FunctionAttribute::JumpTable => write!(f, "jumptable"),
+            FunctionAttribute::MinimizeSize => write!(f, "minsize"),
+            FunctionAttribute::Naked => write!(f, "naked"),
+            FunctionAttribute::NoBuiltin => write!(f, "nobuiltin"),
+            FunctionAttribute::NoCFCheck => write!(f, "nocf_check"),
+            FunctionAttribute::NoDuplicate => write!(f, "noduplicate"),
+            FunctionAttribute::NoFree => write!(f, "nofree"),
+            FunctionAttribute::NoImplicitFloat => write!(f, "noimplicitfloat"),
+            FunctionAttribute::NoInline => write!(f, "noinline"),
+            #[cfg(feature = "llvm-11-or-greater")]
+            FunctionAttribute::NoMerge => write!(f, "nomerge"),
+            FunctionAttribute::NonLazyBind => write!(f, "nonlazybind"),
+            FunctionAttribute::NoRedZone => write!(f, "noredzone"),
+            FunctionAttribute::NoReturn => write!(f, "noreturn"),
+            FunctionAttribute::NoRecurse => write!(f, "norecurse"),
+            FunctionAttribute::WillReturn => write!(f, "willreturn"),
+            FunctionAttribute::ReturnsTwice => write!(f, "returns_twice"),
+            FunctionAttribute::NoSync => write!(f, "nosync"),
+            FunctionAttribute::NoUnwind => write!(f, "nounwind"),
+            #[cfg(feature = "llvm-11-or-greater")]
+            FunctionAttribute::NullPointerIsValid => write!(f, "null_pointer_is_valid"),
+            FunctionAttribute::OptForFuzzing => write!(f, "optforfuzzing"),
+            FunctionAttribute::OptNone => write!(f, "optnone"),
+            FunctionAttribute::OptSize => write!(f, "optsize"),
+            FunctionAttribute::ReadNone => write!(f, "readnone"),
+            FunctionAttribute::ReadOnly => write!(f, "readonly"),
+            FunctionAttribute::WriteOnly => write!(f, "writeonly"),
+            FunctionAttribute::ArgMemOnly => write!(f, "argmemonly"),
+            FunctionAttribute::SafeStack => write!(f, "safestack"),
+            FunctionAttribute::SanitizeAddress => write!(f, "sanitize_address"),
+            FunctionAttribute::SanitizeMemory => write!(f, "sanitize_memory"),
+            FunctionAttribute::SanitizeThread => write!(f, "sanitize_thread"),
+            FunctionAttribute::SanitizeHWAddress => write!(f, "sanitize_hwaddress"),
+            FunctionAttribute::SanitizeMemTag => write!(f, "sanitize_memtag"),
+            FunctionAttribute::ShadowCallStack => write!(f, "shadowcallstack"),
+            FunctionAttribute::SpeculativeLoadHardening => write!(f, "speculative_load_hardening"),
+            FunctionAttribute::Speculatable => write!(f, "speculatable"),
+            FunctionAttribute::StackProtect => write!(f, "ssp"),
+            FunctionAttribute::StackProtectReq => write!(f, "sspreq"),
+            FunctionAttribute::StackProtectStrong => write!(f, "sspstrong"),
+            FunctionAttribute::StrictFP => write!(f, "strictfp"),
+            FunctionAttribute::UWTable => write!(f, "uwtable"),
+            #[cfg(feature = "llvm-16-or-greater")]
+            FunctionAttribute::Memory { default, argmem, inaccessible_mem } => {
+                // memory attribute with per-location effects
+                // If all are the same, use the short form
+                if default == argmem && argmem == inaccessible_mem {
+                    write!(f, "memory({})", default)
+                } else {
+                    let mut parts = Vec::new();
+                    if *default != MemoryEffect::None {
+                        parts.push(format!("{}", default));
+                    }
+                    if *argmem != *default {
+                        parts.push(format!("argmem: {}", argmem));
+                    }
+                    if *inaccessible_mem != *default {
+                        parts.push(format!("inaccessiblemem: {}", inaccessible_mem));
+                    }
+                    write!(f, "memory({})", parts.join(", "))
+                }
+            },
+            FunctionAttribute::StringAttribute { kind, value } => {
+                if value.is_empty() {
+                    write!(f, "\"{}\"", kind)
+                } else {
+                    write!(f, "\"{}\"=\"{}\"", kind, value)
+                }
+            },
+            FunctionAttribute::UnknownAttribute => Ok(()),
+        }
+    }
+}
+
+impl Display for ParameterAttribute {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ParameterAttribute::ZeroExt => write!(f, "zeroext"),
+            ParameterAttribute::SignExt => write!(f, "signext"),
+            ParameterAttribute::InReg => write!(f, "inreg"),
+            #[cfg(feature = "llvm-11-or-lower")]
+            ParameterAttribute::ByVal => write!(f, "byval"),
+            #[cfg(feature = "llvm-12-or-greater")]
+            ParameterAttribute::ByVal(ty) => write!(f, "byval({})", ty),
+            #[cfg(feature = "llvm-11")]
+            ParameterAttribute::Preallocated => write!(f, "preallocated"),
+            #[cfg(feature = "llvm-12-or-greater")]
+            ParameterAttribute::Preallocated(ty) => write!(f, "preallocated({})", ty),
+            #[cfg(feature = "llvm-12-or-lower")]
+            ParameterAttribute::InAlloca => write!(f, "inalloca"),
+            #[cfg(feature = "llvm-13-or-greater")]
+            ParameterAttribute::InAlloca(ty) => write!(f, "inalloca({})", ty),
+            #[cfg(feature = "llvm-11-or-lower")]
+            ParameterAttribute::SRet => write!(f, "sret"),
+            #[cfg(feature = "llvm-12-or-greater")]
+            ParameterAttribute::SRet(ty) => write!(f, "sret({})", ty),
+            ParameterAttribute::Alignment(n) => write!(f, "align {}", n),
+            ParameterAttribute::NoAlias => write!(f, "noalias"),
+            ParameterAttribute::NoCapture => write!(f, "nocapture"),
+            ParameterAttribute::NoFree => write!(f, "nofree"),
+            ParameterAttribute::Nest => write!(f, "nest"),
+            ParameterAttribute::Returned => write!(f, "returned"),
+            ParameterAttribute::NonNull => write!(f, "nonnull"),
+            ParameterAttribute::Dereferenceable(n) => write!(f, "dereferenceable({})", n),
+            ParameterAttribute::DereferenceableOrNull(n) => write!(f, "dereferenceable_or_null({})", n),
+            ParameterAttribute::SwiftSelf => write!(f, "swiftself"),
+            ParameterAttribute::SwiftError => write!(f, "swifterror"),
+            ParameterAttribute::ImmArg => write!(f, "immarg"),
+            #[cfg(feature = "llvm-11-or-greater")]
+            ParameterAttribute::NoUndef => write!(f, "noundef"),
+            ParameterAttribute::StringAttribute { kind, value } => {
+                if value.is_empty() {
+                    write!(f, "\"{}\"", kind)
+                } else {
+                    write!(f, "\"{}\"=\"{}\"", kind, value)
+                }
+            },
+            ParameterAttribute::UnknownAttribute => Ok(()),
+            #[cfg(feature = "llvm-12-or-greater")]
+            ParameterAttribute::UnknownTypeAttribute(_) => Ok(()),
+        }
+    }
+}
+
+impl Display for Parameter {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.ty)?;
+        for attr in &self.attributes {
+            let s = attr.to_string();
+            if !s.is_empty() {
+                write!(f, " {}", s)?;
+            }
+        }
+        write!(f, " {}", self.name)?;
+        Ok(())
+    }
+}
+
+/// Helper: write the common prefix for function declarations and definitions
+fn fmt_func_prefix(
+    f: &mut fmt::Formatter,
+    keyword: &str,
+    linkage: &Linkage,
+    visibility: &Visibility,
+    dll_storage_class: &DLLStorageClass,
+    calling_convention: &CallingConvention,
+    return_attributes: &[ParameterAttribute],
+    return_type: &TypeRef,
+    name: &str,
+    parameters: &[Parameter],
+    is_var_arg: bool,
+    function_attributes: &[FunctionAttribute],
+    alignment: u32,
+    garbage_collector_name: &Option<String>,
+    section: Option<&str>,
+) -> fmt::Result {
+    write!(f, "{}", keyword)?;
+    let linkage_str = linkage.to_string();
+    if !linkage_str.is_empty() {
+        write!(f, " {}", linkage_str)?;
+    }
+    let vis = visibility.to_string();
+    if !vis.is_empty() {
+        write!(f, " {}", vis)?;
+    }
+    let dll = dll_storage_class.to_string();
+    if !dll.is_empty() {
+        write!(f, " {}", dll)?;
+    }
+    let cc = calling_convention.to_string();
+    if !cc.is_empty() {
+        write!(f, " {}", cc)?;
+    }
+    // return attributes
+    for attr in return_attributes {
+        let s = attr.to_string();
+        if !s.is_empty() {
+            write!(f, " {}", s)?;
+        }
+    }
+    write!(f, " {} @{}(", return_type, name)?;
+    for (i, param) in parameters.iter().enumerate() {
+        if i > 0 {
+            write!(f, ", ")?;
+        }
+        write!(f, "{}", param)?;
+    }
+    if is_var_arg {
+        if !parameters.is_empty() {
+            write!(f, ", ")?;
+        }
+        write!(f, "...")?;
+    }
+    write!(f, ")")?;
+    // function attributes
+    for attr in function_attributes {
+        let s = attr.to_string();
+        if !s.is_empty() {
+            write!(f, " {}", s)?;
+        }
+    }
+    if let Some(section) = section {
+        write!(f, " section \"{}\"", section)?;
+    }
+    if alignment != 0 {
+        write!(f, " align {}", alignment)?;
+    }
+    if let Some(gc) = garbage_collector_name {
+        write!(f, " gc \"{}\"", gc)?;
+    }
+    Ok(())
+}
+
+impl Display for FunctionDeclaration {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt_func_prefix(
+            f,
+            "declare",
+            &self.linkage,
+            &self.visibility,
+            &self.dll_storage_class,
+            &self.calling_convention,
+            &self.return_attributes,
+            &self.return_type,
+            &self.name,
+            &self.parameters,
+            self.is_var_arg,
+            &[], // declarations don't have function_attributes in this struct
+            self.alignment,
+            &self.garbage_collector_name,
+            None,
+        )
+    }
+}
+
+impl Display for Function {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt_func_prefix(
+            f,
+            "define",
+            &self.linkage,
+            &self.visibility,
+            &self.dll_storage_class,
+            &self.calling_convention,
+            &self.return_attributes,
+            &self.return_type,
+            &self.name,
+            &self.parameters,
+            self.is_var_arg,
+            &self.function_attributes,
+            self.alignment,
+            &self.garbage_collector_name,
+            self.section.as_deref(),
+        )?;
+        if let Some(pf) = &self.personality_function {
+            write!(f, " personality {}", pf)?;
+        }
+        writeln!(f, " {{")?;
+        for (i, bb) in self.basic_blocks.iter().enumerate() {
+            if i > 0 {
+                writeln!(f)?;
+            }
+            write!(f, "{}", bb)?;
+        }
+        write!(f, "}}")
+    }
+}
 
 // ********* //
 // from_llvm //

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1,8 +1,8 @@
-use crate::constant::ConstantRef;
+use crate::constant::{Constant, ConstantRef};
 use crate::debugloc::{DebugLoc, HasDebugLoc};
 use crate::function::{CallingConvention, FunctionAttribute, ParameterAttribute};
 use crate::name::Name;
-use crate::operand::Operand;
+use crate::operand::{fmt_operand_value, fmt_operand_with_attrs, Operand};
 use crate::predicates::*;
 #[cfg(feature = "llvm-14-or-lower")]
 use crate::types::NamedStructDef;
@@ -631,11 +631,8 @@ macro_rules! binop_display {
     ($inst:ty, $dispname:expr) => {
         impl Display for $inst {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                write!(
-                    f,
-                    "{} = {} {}, {}",
-                    &self.dest, $dispname, &self.operand0, &self.operand1,
-                )?;
+                write!(f, "{} = {} {}, ", &self.dest, $dispname, &self.operand0)?;
+                fmt_operand_value(&self.operand1, f)?;
                 if self.debugloc.is_some() {
                     write!(f, " (with debugloc)")?;
                 }
@@ -662,11 +659,8 @@ macro_rules! binop_display_with_flags {
                 // Write any flags we may have
                 $( #[cfg(feature = $required_feature)] if self.$flag_field { write!(f, " {}", $flag_display)?; })*
 
-                write!(
-                    f,
-                    " {}, {}",
-                    &self.operand0, &self.operand1,
-                )?;
+                write!(f, " {}, ", &self.operand0)?;
+                fmt_operand_value(&self.operand1, f)?;
 
                 if self.debugloc.is_some() {
                     write!(f, " (with debugloc)")?;
@@ -1711,13 +1705,13 @@ fn gep_type<'o>(
 
 impl Display for GetElementPtr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // Like for `Load` (see notes there), we differ from the LLVM IR text
-        // syntax here because we don't include the destination type (that's a
-        // little hard to get for us here, and it's derivable from the other
-        // information anyway)
         write!(f, "{} = getelementptr ", &self.dest)?;
         if self.in_bounds {
             write!(f, "inbounds ")?;
+        }
+        #[cfg(feature = "llvm-14-or-greater")]
+        {
+            write!(f, "{}, ", &self.source_element_type)?;
         }
         write!(f, "{}", &self.address)?;
         for idx in &self.indices {
@@ -1951,11 +1945,8 @@ impl Typed for ICmp {
 
 impl Display for ICmp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{} = icmp {} {}, {}",
-            &self.dest, &self.predicate, &self.operand0, &self.operand1,
-        )?;
+        write!(f, "{} = icmp {} {}, ", &self.dest, &self.predicate, &self.operand0)?;
+        fmt_operand_value(&self.operand1, f)?;
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -1998,11 +1989,8 @@ impl Typed for FCmp {
 
 impl Display for FCmp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{} = fcmp {} {}, {}",
-            &self.dest, &self.predicate, &self.operand0, &self.operand1,
-        )?;
+        write!(f, "{} = fcmp {} {}, ", &self.dest, &self.predicate, &self.operand0)?;
+        fmt_operand_value(&self.operand1, f)?;
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -2030,13 +2018,13 @@ impl Display for Phi {
             .incoming_values
             .get(0)
             .expect("Phi with no incoming values");
-        write!(
-            f,
-            "{} = phi {} [ {}, {} ]",
-            &self.dest, &self.to_type, first_val, first_label,
-        )?;
+        write!(f, "{} = phi {} [ ", &self.dest, &self.to_type)?;
+        fmt_operand_value(first_val, f)?;
+        write!(f, ", {} ]", first_label)?;
         for (val, label) in &self.incoming_values[1 ..] {
-            write!(f, ", [ {}, {} ]", val, label)?;
+            write!(f, ", [ ")?;
+            fmt_operand_value(val, f)?;
+            write!(f, ", {} ]", label)?;
         }
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
@@ -2141,30 +2129,75 @@ impl Typed for Call {
 
 impl Display for Call {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // We choose not to include all the detailed information available in
-        // the `Call` struct in this `Display` impl
         if let Some(dest) = &self.dest {
             write!(f, "{} = ", dest)?;
         }
         if self.is_tail_call {
             write!(f, "tail ")?;
         }
-        write!(
-            f,
-            "call {}(",
-            match &self.function {
-                Either::Left(_) => "<inline assembly>".into(),
-                Either::Right(op) => format!("{}", op),
-            }
-        )?;
-        for (i, (arg, _)) in self.arguments.iter().enumerate() {
-            if i == self.arguments.len() - 1 {
-                write!(f, "{}", arg)?;
-            } else {
-                write!(f, "{}, ", arg)?;
+        write!(f, "call ")?;
+        let cc = self.calling_convention.to_string();
+        if !cc.is_empty() {
+            write!(f, "{} ", cc)?;
+        }
+        for attr in &self.return_attributes {
+            let s = attr.to_string();
+            if !s.is_empty() {
+                write!(f, "{} ", s)?;
             }
         }
+        // For LLVM 15+, emit the function type (or return type for simple calls)
+        // For LLVM 14 and lower, the pointer type includes the pointee (function) type
+        #[cfg(feature = "llvm-15-or-greater")]
+        {
+            match self.function_ty.as_ref() {
+                Type::FuncType { result_type, is_var_arg, .. } if *is_var_arg => {
+                    // varargs: must emit the full function type
+                    write!(f, "{} ", self.function_ty)?;
+                },
+                Type::FuncType { result_type, .. } => {
+                    write!(f, "{} ", result_type)?;
+                },
+                _ => {
+                    write!(f, "{} ", self.function_ty)?;
+                },
+            }
+        }
+        // Write the callee
+        match &self.function {
+            Either::Left(_) => write!(f, "<inline assembly>")?,
+            Either::Right(Operand::ConstantOperand(cref)) => {
+                match cref.as_ref() {
+                    Constant::GlobalReference { name, .. } => {
+                        match name {
+                            Name::Name(n) => write!(f, "@{}", n)?,
+                            Name::Number(n) => write!(f, "@{}", n)?,
+                        }
+                    },
+                    _ => write!(f, "{}", cref)?,
+                }
+            },
+            #[cfg(feature = "llvm-14-or-lower")]
+            Either::Right(op) => write!(f, "{}", op)?,
+            #[cfg(feature = "llvm-15-or-greater")]
+            Either::Right(Operand::LocalOperand { name, .. }) => write!(f, "{}", name)?,
+            #[cfg(feature = "llvm-15-or-greater")]
+            Either::Right(op) => write!(f, "{}", op)?,
+        }
+        write!(f, "(")?;
+        for (i, (arg, attrs)) in self.arguments.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            fmt_operand_with_attrs(arg, attrs, f)?;
+        }
         write!(f, ")")?;
+        for attr in &self.function_attributes {
+            let s = attr.to_string();
+            if !s.is_empty() {
+                write!(f, " {}", s)?;
+            }
+        }
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -2503,7 +2536,6 @@ pub struct LandingPadClause {}
 // from_llvm //
 // ********* //
 
-use crate::constant::Constant;
 use crate::from_llvm::*;
 use crate::function::FunctionContext;
 use crate::llvm_sys::*;

--- a/src/module.rs
+++ b/src/module.rs
@@ -4,8 +4,9 @@ use crate::from_llvm::StringInterner;
 use crate::function::{Function, FunctionAttribute, FunctionDeclaration, GroupID};
 use crate::llvm_sys::*;
 use crate::name::Name;
-use crate::types::{FPType, Type, TypeRef, Typed, Types, TypesBuilder};
+use crate::types::{FPType, NamedStructDef, Type, TypeRef, Typed, Types, TypesBuilder};
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt::{self, Display};
 use std::path::Path;
 
 /// See [LLVM 14 docs on Module Structure](https://releases.llvm.org/14.0.0/docs/LangRef.html#module-structure)
@@ -372,6 +373,296 @@ pub enum SelectionKind {
     Largest,
     NoDuplicates,
     SameSize,
+}
+
+// ======= //
+// Display  //
+// ======= //
+
+/// Helper to format a `Name` with `@` prefix (for globals) instead of `%`
+fn fmt_global_name(name: &Name, f: &mut fmt::Formatter) -> fmt::Result {
+    match name {
+        Name::Name(n) => write!(f, "@{}", n),
+        Name::Number(n) => write!(f, "@{}", n),
+    }
+}
+
+impl Display for Linkage {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Linkage::Private => write!(f, "private"),
+            Linkage::Internal => write!(f, "internal"),
+            Linkage::External => Ok(()), // external is the default, omit it
+            Linkage::ExternalWeak => write!(f, "extern_weak"),
+            Linkage::AvailableExternally => write!(f, "available_externally"),
+            Linkage::LinkOnceAny => write!(f, "linkonce"),
+            Linkage::LinkOnceODR => write!(f, "linkonce_odr"),
+            Linkage::LinkOnceODRAutoHide => write!(f, "linkonce_odr"),
+            Linkage::WeakAny => write!(f, "weak"),
+            Linkage::WeakODR => write!(f, "weak_odr"),
+            Linkage::Common => write!(f, "common"),
+            Linkage::Appending => write!(f, "appending"),
+            Linkage::DLLImport => write!(f, "dllimport"),
+            Linkage::DLLExport => write!(f, "dllexport"),
+            Linkage::Ghost => write!(f, "extern_weak"),
+            Linkage::LinkerPrivate => write!(f, "linker_private"),
+            Linkage::LinkerPrivateWeak => write!(f, "linker_private_weak"),
+        }
+    }
+}
+
+impl Display for Visibility {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Visibility::Default => Ok(()), // default is implicit
+            Visibility::Hidden => write!(f, "hidden"),
+            Visibility::Protected => write!(f, "protected"),
+        }
+    }
+}
+
+impl Display for DLLStorageClass {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            DLLStorageClass::Default => Ok(()),
+            DLLStorageClass::Import => write!(f, "dllimport"),
+            DLLStorageClass::Export => write!(f, "dllexport"),
+        }
+    }
+}
+
+impl Display for ThreadLocalMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ThreadLocalMode::NotThreadLocal => Ok(()),
+            ThreadLocalMode::GeneralDynamic => write!(f, "thread_local"),
+            ThreadLocalMode::LocalDynamic => write!(f, "thread_local(localdynamic)"),
+            ThreadLocalMode::InitialExec => write!(f, "thread_local(initialexec)"),
+            ThreadLocalMode::LocalExec => write!(f, "thread_local(localexec)"),
+        }
+    }
+}
+
+impl Display for UnnamedAddr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            UnnamedAddr::Local => write!(f, "local_unnamed_addr"),
+            UnnamedAddr::Global => write!(f, "unnamed_addr"),
+        }
+    }
+}
+
+impl Display for SelectionKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SelectionKind::Any => write!(f, "any"),
+            SelectionKind::ExactMatch => write!(f, "exactmatch"),
+            SelectionKind::Largest => write!(f, "largest"),
+            SelectionKind::NoDuplicates => write!(f, "noduplicates"),
+            SelectionKind::SameSize => write!(f, "samesize"),
+        }
+    }
+}
+
+impl Display for Comdat {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "comdat({})", self.name)
+    }
+}
+
+impl Display for GlobalVariable {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt_global_name(&self.name, f)?;
+        write!(f, " =")?;
+        // linkage
+        let linkage = self.linkage.to_string();
+        if !linkage.is_empty() {
+            write!(f, " {}", linkage)?;
+        }
+        // visibility
+        let vis = self.visibility.to_string();
+        if !vis.is_empty() {
+            write!(f, " {}", vis)?;
+        }
+        // dll storage class
+        let dll = self.dll_storage_class.to_string();
+        if !dll.is_empty() {
+            write!(f, " {}", dll)?;
+        }
+        // thread local
+        let tlm = self.thread_local_mode.to_string();
+        if !tlm.is_empty() {
+            write!(f, " {}", tlm)?;
+        }
+        // unnamed_addr
+        if let Some(ua) = &self.unnamed_addr {
+            write!(f, " {}", ua)?;
+        }
+        // addrspace
+        if self.addr_space != 0 {
+            write!(f, " addrspace({})", self.addr_space)?;
+        }
+        // constant or global
+        if self.is_constant {
+            write!(f, " constant")?;
+        } else {
+            write!(f, " global")?;
+        }
+        // type and initializer
+        write!(f, " {}", self.value_type)?;
+        if let Some(init) = &self.initializer {
+            write!(f, " ")?;
+            crate::operand::fmt_constant_value(init, f)?;
+        }
+        // section
+        if let Some(section) = &self.section {
+            write!(f, ", section \"{}\"", section)?;
+        }
+        // comdat
+        if let Some(comdat) = &self.comdat {
+            write!(f, ", {}", comdat)?;
+        }
+        // alignment
+        if self.alignment != 0 {
+            write!(f, ", align {}", self.alignment)?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for GlobalAlias {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt_global_name(&self.name, f)?;
+        write!(f, " =")?;
+        // linkage
+        let linkage = self.linkage.to_string();
+        if !linkage.is_empty() {
+            write!(f, " {}", linkage)?;
+        }
+        // visibility
+        let vis = self.visibility.to_string();
+        if !vis.is_empty() {
+            write!(f, " {}", vis)?;
+        }
+        // dll storage class
+        let dll = self.dll_storage_class.to_string();
+        if !dll.is_empty() {
+            write!(f, " {}", dll)?;
+        }
+        // thread local
+        let tlm = self.thread_local_mode.to_string();
+        if !tlm.is_empty() {
+            write!(f, " {}", tlm)?;
+        }
+        // unnamed_addr
+        if let Some(ua) = &self.unnamed_addr {
+            write!(f, " {}", ua)?;
+        }
+        write!(f, " alias {}, {}", self.ty, self.aliasee)?;
+        Ok(())
+    }
+}
+
+impl Display for GlobalIFunc {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt_global_name(&self.name, f)?;
+        write!(f, " =")?;
+        // linkage
+        let linkage = self.linkage.to_string();
+        if !linkage.is_empty() {
+            write!(f, " {}", linkage)?;
+        }
+        // visibility
+        let vis = self.visibility.to_string();
+        if !vis.is_empty() {
+            write!(f, " {}", vis)?;
+        }
+        write!(f, " ifunc {}, {}", self.ty, self.resolver_fn)?;
+        Ok(())
+    }
+}
+
+impl Display for Module {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // source_filename
+        if !self.source_file_name.is_empty() {
+            writeln!(f, "source_filename = \"{}\"", self.source_file_name)?;
+        }
+        // target datalayout
+        if !self.data_layout.layout_str.is_empty() {
+            writeln!(f, "target datalayout = \"{}\"", self.data_layout.layout_str)?;
+        }
+        // target triple
+        if let Some(triple) = &self.target_triple {
+            writeln!(f, "target triple = \"{}\"", triple)?;
+        }
+        writeln!(f)?;
+
+        // module-level inline assembly
+        if !self.inline_assembly.is_empty() {
+            for line in self.inline_assembly.lines() {
+                writeln!(f, "module asm \"{}\"", line)?;
+            }
+            writeln!(f)?;
+        }
+
+        // named struct type definitions
+        let mut struct_names: Vec<&String> = self.types.all_struct_names().collect();
+        struct_names.sort();
+        for name in &struct_names {
+            match self.types.named_struct_def(name) {
+                Some(NamedStructDef::Opaque) => {
+                    writeln!(f, "%{} = type opaque", name)?;
+                },
+                Some(NamedStructDef::Defined(ty)) => {
+                    writeln!(f, "%{} = type {}", name, ty)?;
+                },
+                None => {},
+            }
+        }
+        if !struct_names.is_empty() {
+            writeln!(f)?;
+        }
+
+        // global variables
+        for gv in &self.global_vars {
+            writeln!(f, "{}", gv)?;
+        }
+        if !self.global_vars.is_empty() {
+            writeln!(f)?;
+        }
+
+        // global aliases
+        for ga in &self.global_aliases {
+            writeln!(f, "{}", ga)?;
+        }
+        if !self.global_aliases.is_empty() {
+            writeln!(f)?;
+        }
+
+        // global ifuncs
+        for gi in &self.global_ifuncs {
+            writeln!(f, "{}", gi)?;
+        }
+        if !self.global_ifuncs.is_empty() {
+            writeln!(f)?;
+        }
+
+        // function declarations
+        for decl in &self.func_declarations {
+            writeln!(f, "{}", decl)?;
+        }
+        if !self.func_declarations.is_empty() {
+            writeln!(f)?;
+        }
+
+        // function definitions
+        for func in &self.functions {
+            writeln!(f, "{}", func)?;
+        }
+
+        Ok(())
+    }
 }
 
 /// See [LLVM 14 docs on Data Layout](https://releases.llvm.org/14.0.0/docs/LangRef.html#data-layout)

--- a/src/operand.rs
+++ b/src/operand.rs
@@ -1,3 +1,4 @@
+use crate::function::ParameterAttribute;
 use crate::types::{TypeRef, Typed, Types};
 use crate::{ConstantRef, Name};
 use std::fmt::{self, Display};
@@ -52,6 +53,186 @@ impl Display for Operand {
             Operand::ConstantOperand(cref) => write!(f, "{}", &cref),
             Operand::MetadataOperand => write!(f, "<metadata>"),
         }
+    }
+}
+
+/// Format just the value part of an operand (without the type prefix).
+/// For example, a `LocalOperand { name: %3, ty: i32 }` would display as just `%3`
+/// instead of `i32 %3`.
+pub fn fmt_operand_value(op: &Operand, f: &mut fmt::Formatter) -> fmt::Result {
+    match op {
+        Operand::LocalOperand { name, .. } => write!(f, "{}", name),
+        Operand::ConstantOperand(cref) => fmt_constant_value(cref, f),
+        Operand::MetadataOperand => write!(f, "<metadata>"),
+    }
+}
+
+/// Format just the value part of a constant (without its type prefix).
+/// For constants like Int that display as "i32 5", this returns just "5".
+/// For aggregate constants like Array/Struct/Vector, returns the value body
+/// (including inner element types).
+pub(crate) fn fmt_constant_value(cref: &ConstantRef, f: &mut fmt::Formatter) -> fmt::Result {
+    use crate::constant::Constant;
+    match cref.as_ref() {
+        Constant::Int { bits, value } => {
+            if *bits == 1 {
+                if *value == 0 {
+                    write!(f, "false")
+                } else {
+                    write!(f, "true")
+                }
+            } else {
+                match *bits {
+                    16 => {
+                        let signed_val = (*value & 0xFFFF) as i16;
+                        if signed_val > -1000 {
+                            write!(f, "{}", signed_val)
+                        } else {
+                            write!(f, "{}", *value)
+                        }
+                    },
+                    32 => {
+                        let signed_val = (*value & 0xFFFF_FFFF) as i32;
+                        if signed_val > -1000 {
+                            write!(f, "{}", signed_val)
+                        } else {
+                            write!(f, "{}", *value)
+                        }
+                    },
+                    64 => {
+                        let signed_val = *value as i64;
+                        if signed_val > -1000 {
+                            write!(f, "{}", signed_val)
+                        } else {
+                            write!(f, "{}", *value)
+                        }
+                    },
+                    _ => write!(f, "{}", *value),
+                }
+            }
+        },
+        Constant::Null(_) => write!(f, "null"),
+        Constant::AggregateZero(_) => write!(f, "zeroinitializer"),
+        Constant::Undef(_) => write!(f, "undef"),
+        #[cfg(feature = "llvm-12-or-greater")]
+        Constant::Poison(_) => write!(f, "poison"),
+        Constant::GlobalReference { name, .. } => {
+            match name {
+                Name::Name(n) => write!(f, "@{}", n),
+                Name::Number(n) => write!(f, "@{}", n),
+            }
+        },
+        Constant::TokenNone => write!(f, "none"),
+        // These already display without a type prefix — just the value body
+        Constant::Array { .. } | Constant::Vector(..) | Constant::Struct { .. } => {
+            write!(f, "{}", cref)
+        },
+        // Float Display includes the type name (e.g., "double 3.14"), extract just the value
+        Constant::Float(float) => {
+            use crate::constant::Float;
+            match float {
+                Float::Single(s) => write!(f, "{}", s),
+                Float::Double(d) => write!(f, "{}", d),
+                _ => write!(f, "{}", float), // other float types: fallback
+            }
+        },
+        // For everything else (constant expressions), use full display
+        _ => write!(f, "{}", cref),
+    }
+}
+
+/// Format an operand with parameter attributes inserted between the type and value.
+/// In LLVM IR syntax, call argument attributes go between type and value: `ptr nonnull %x`
+pub fn fmt_operand_with_attrs(
+    op: &Operand,
+    attrs: &[ParameterAttribute],
+    f: &mut fmt::Formatter,
+) -> fmt::Result {
+    if attrs.is_empty() {
+        return write!(f, "{}", op);
+    }
+    match op {
+        Operand::LocalOperand { name, ty } => {
+            write!(f, "{}", ty)?;
+            for attr in attrs {
+                let s = attr.to_string();
+                if !s.is_empty() {
+                    write!(f, " {}", s)?;
+                }
+            }
+            write!(f, " {}", name)
+        },
+        Operand::ConstantOperand(cref) => {
+            use crate::constant::Constant;
+            // For constants that display as "type value", insert attrs between type and value
+            // We need to write the type, then attrs, then the value
+            match cref.as_ref() {
+                Constant::Int { bits, .. } => {
+                    write!(f, "i{}", bits)?;
+                    for attr in attrs {
+                        let s = attr.to_string();
+                        if !s.is_empty() {
+                            write!(f, " {}", s)?;
+                        }
+                    }
+                    write!(f, " ")?;
+                    fmt_constant_value(cref, f)
+                },
+                Constant::GlobalReference { name, ty } => {
+                    match ty.as_ref() {
+                        crate::types::Type::FuncType { .. } => write!(f, "{}", ty)?,
+                        _ => {
+                            #[cfg(feature = "llvm-14-or-lower")]
+                            write!(f, "{}*", ty)?;
+                            #[cfg(feature = "llvm-15-or-greater")]
+                            write!(f, "ptr")?;
+                        },
+                    }
+                    for attr in attrs {
+                        let s = attr.to_string();
+                        if !s.is_empty() {
+                            write!(f, " {}", s)?;
+                        }
+                    }
+                    write!(f, " ")?;
+                    match name {
+                        Name::Name(n) => write!(f, "@{}", n),
+                        Name::Number(n) => write!(f, "@{}", n),
+                    }
+                },
+                Constant::Null(ty) => {
+                    write!(f, "{}", ty)?;
+                    for attr in attrs {
+                        let s = attr.to_string();
+                        if !s.is_empty() {
+                            write!(f, " {}", s)?;
+                        }
+                    }
+                    write!(f, " null")
+                },
+                // Fallback: write the full constant then attrs after
+                _ => {
+                    write!(f, "{}", cref)?;
+                    for attr in attrs {
+                        let s = attr.to_string();
+                        if !s.is_empty() {
+                            write!(f, " {}", s)?;
+                        }
+                    }
+                    Ok(())
+                },
+            }
+        },
+        Operand::MetadataOperand => {
+            write!(f, "<metadata>")?;
+            for attr in attrs {
+                let s = attr.to_string();
+                if !s.is_empty() {
+                    write!(f, " {}", s)?;
+                }
+            }
+            Ok(())
+        },
     }
 }
 

--- a/src/terminator.rs
+++ b/src/terminator.rs
@@ -1,6 +1,7 @@
 use crate::debugloc::{DebugLoc, HasDebugLoc};
 use crate::function::{CallingConvention, FunctionAttribute, ParameterAttribute};
 use crate::instruction::{HasResult, InlineAssembly};
+use crate::operand::fmt_operand_with_attrs;
 use crate::types::{Typed, Types};
 use crate::{Constant, ConstantRef, Name, Operand, Type, TypeRef};
 use either::Either;
@@ -286,13 +287,13 @@ impl Display for Switch {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "switch {}, label {} [ ",
+            "switch {}, label {} [\n",
             &self.operand, &self.default_dest,
         )?;
         for (val, label) in &self.dests {
-            write!(f, "{}, label {}; ", val, label)?;
+            write!(f, "    {}, label {}\n", val, label)?;
         }
-        write!(f, "]")?;
+        write!(f, "  ]")?;
         if self.debugloc.is_some() {
             write!(f, " (with debugloc)")?;
         }
@@ -383,23 +384,57 @@ impl Typed for Invoke {
 
 impl Display for Invoke {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // Like with `Call`, we choose not to include all the detailed
-        // information available in the `Invoke` struct in this `Display` impl
-        write!(
-            f,
-            "{} = invoke {}(",
-            &self.result,
-            match &self.function {
-                Either::Left(_) => "<inline assembly>".into(),
-                Either::Right(op) => format!("{}", op),
+        write!(f, "{} = invoke ", &self.result)?;
+        let cc = self.calling_convention.to_string();
+        if !cc.is_empty() {
+            write!(f, "{} ", cc)?;
+        }
+        for attr in &self.return_attributes {
+            let s = attr.to_string();
+            if !s.is_empty() {
+                write!(f, "{} ", s)?;
             }
-        )?;
-        for (i, (arg, _)) in self.arguments.iter().enumerate() {
-            if i == self.arguments.len() - 1 {
-                write!(f, "{}", arg)?;
-            } else {
-                write!(f, "{}, ", arg)?;
+        }
+        #[cfg(feature = "llvm-15-or-greater")]
+        {
+            match self.function_ty.as_ref() {
+                Type::FuncType { result_type, is_var_arg, .. } if *is_var_arg => {
+                    write!(f, "{} ", self.function_ty)?;
+                },
+                Type::FuncType { result_type, .. } => {
+                    write!(f, "{} ", result_type)?;
+                },
+                _ => {
+                    write!(f, "{} ", self.function_ty)?;
+                },
             }
+        }
+        match &self.function {
+            Either::Left(_) => write!(f, "<inline assembly>")?,
+            Either::Right(Operand::ConstantOperand(cref)) => {
+                match cref.as_ref() {
+                    Constant::GlobalReference { name, .. } => {
+                        match name {
+                            Name::Name(n) => write!(f, "@{}", n)?,
+                            Name::Number(n) => write!(f, "@{}", n)?,
+                        }
+                    },
+                    _ => write!(f, "{}", cref)?,
+                }
+            },
+            #[cfg(feature = "llvm-14-or-lower")]
+            Either::Right(op) => write!(f, "{}", op)?,
+            #[cfg(feature = "llvm-15-or-greater")]
+            Either::Right(Operand::LocalOperand { name, .. }) => write!(f, "{}", name)?,
+            #[cfg(feature = "llvm-15-or-greater")]
+            Either::Right(op) => write!(f, "{}", op)?,
+        }
+        write!(f, "(")?;
+        for (i, (arg, attrs)) in self.arguments.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            fmt_operand_with_attrs(arg, attrs, f)?;
         }
         write!(
             f,
@@ -597,24 +632,38 @@ impl Typed for CallBr {
 
 impl Display for CallBr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // Like with `Call` and `Invoke, we choose not to include all the
-        // detailed information available in the `CallBr` struct in this
-        // `Display` impl
-        write!(
-            f,
-            "{} = callbr {}(",
-            &self.result,
-            match &self.function {
-                Either::Left(_) => "<inline assembly>".into(),
-                Either::Right(op) => format!("{}", op),
+        write!(f, "{} = callbr ", &self.result)?;
+        let cc = self.calling_convention.to_string();
+        if !cc.is_empty() {
+            write!(f, "{} ", cc)?;
+        }
+        for attr in &self.return_attributes {
+            let s = attr.to_string();
+            if !s.is_empty() {
+                write!(f, "{} ", s)?;
             }
-        )?;
-        for (i, (arg, _)) in self.arguments.iter().enumerate() {
-            if i == self.arguments.len() - 1 {
-                write!(f, "{}", arg)?;
-            } else {
-                write!(f, "{}, ", arg)?;
+        }
+        match &self.function {
+            Either::Left(_) => write!(f, "<inline assembly>")?,
+            Either::Right(Operand::ConstantOperand(cref)) => {
+                match cref.as_ref() {
+                    Constant::GlobalReference { name, .. } => {
+                        match name {
+                            Name::Name(n) => write!(f, "@{}", n)?,
+                            Name::Number(n) => write!(f, "@{}", n)?,
+                        }
+                    },
+                    _ => write!(f, "{}", cref)?,
+                }
+            },
+            Either::Right(op) => write!(f, "{}", op)?,
+        }
+        write!(f, "(")?;
+        for (i, (arg, attrs)) in self.arguments.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
             }
+            fmt_operand_with_attrs(arg, attrs, f)?;
         }
         write!(f, ") to label {}", &self.return_label)?;
         if self.debugloc.is_some() {

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -484,9 +484,9 @@ fn loopbc() {
     assert_eq!(arg1.1.len(), 1); // should have one parameter attribute
     assert_eq!(lifetimestart.dest, None);
     #[cfg(feature = "llvm-14-or-lower")]
-    let expected_fmt = "call @llvm.lifetime.start.p0i8(i64 40, i8* %4)";
+    let expected_fmt = "call @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %4) nounwind";
     #[cfg(feature = "llvm-15-or-greater")]
-    let expected_fmt = "call @llvm.lifetime.start.p0(i64 40, ptr %3)";
+    let expected_fmt = "call void @llvm.lifetime.start.p0(i64 40, ptr nonnull %3) nounwind";
     assert_eq!(&lifetimestart.to_string(), expected_fmt);
     #[cfg(feature = "llvm-14-or-lower")]
     let memset: &instruction::Call = &bbs[0].instrs[3]
@@ -572,9 +572,9 @@ fn loopbc() {
     );
     assert_eq!(memset.arguments[0].1.len(), 2); // should have two parameter attributes
     #[cfg(feature = "llvm-14-or-lower")]
-    let expected_fmt = "call @llvm.memset.p0i8.i64(i8* %4, i8 0, i64 40, i1 true)";
+    let expected_fmt = "call @llvm.memset.p0i8.i64(i8* nonnull align 16 %4, i8 0, i64 40, i1 true)";
     #[cfg(feature = "llvm-15-or-greater")]
-    let expected_fmt = "call @llvm.memset.p0.i64(ptr %3, i8 0, i64 40, i1 true)";
+    let expected_fmt = "call void @llvm.memset.p0.i64(ptr nonnull align 16 %3, i8 0, i64 40, i1 true)";
     assert_eq!(&memset.to_string(), expected_fmt);
     #[cfg(feature = "llvm-12-or-lower")]
     {
@@ -598,7 +598,7 @@ fn loopbc() {
         );
         assert_eq!(add.dest, Name::Number(5));
         assert_eq!(module.type_of(add), module.types.i32());
-        assert_eq!(&add.to_string(), "%5 = add i32 %1, i32 -1");
+        assert_eq!(&add.to_string(), "%5 = add i32 %1, -1");
     }
     #[cfg(feature = "llvm-13")]
     {
@@ -619,7 +619,7 @@ fn loopbc() {
         );
         assert_eq!(add.dest, Name::Number(7));
         assert_eq!(module.type_of(add), module.types.i32());
-        assert_eq!(&add.to_string(), "%7 = add i32 %0, i32 3");
+        assert_eq!(&add.to_string(), "%7 = add i32 %0, 3");
     }
     #[cfg(feature = "llvm-14-or-greater")]
     {
@@ -648,11 +648,11 @@ fn loopbc() {
         #[cfg(feature = "llvm-17-or-greater")]
         assert_eq!(add.nsw, true);
         #[cfg(feature = "llvm-14-or-lower")]
-        assert_eq!(&add.to_string(), "%8 = add i32 %0, i32 3");
+        assert_eq!(&add.to_string(), "%8 = add i32 %0, 3");
         #[cfg(any(feature = "llvm-15", feature = "llvm-16"))]
-        assert_eq!(&add.to_string(), "%7 = add i32 %0, i32 3");
+        assert_eq!(&add.to_string(), "%7 = add i32 %0, 3");
         #[cfg(feature = "llvm-17-or-greater")]
-        assert_eq!(&add.to_string(), "%7 = add nsw i32 %0, i32 3");
+        assert_eq!(&add.to_string(), "%7 = add nsw i32 %0, 3");
     }
     #[cfg(feature = "llvm-12-or-lower")]
     {
@@ -676,7 +676,7 @@ fn loopbc() {
             }))
         );
         assert_eq!(module.type_of(icmp), module.types.bool());
-        assert_eq!(&icmp.to_string(), "%6 = icmp ult i32 %5, i32 10");
+        assert_eq!(&icmp.to_string(), "%6 = icmp ult i32 %5, 10");
     }
     #[cfg(feature = "llvm-13")]
     {
@@ -700,7 +700,7 @@ fn loopbc() {
             }))
         );
         assert_eq!(module.type_of(icmp), module.types.bool());
-        assert_eq!(&icmp.to_string(), "%5 = icmp slt i32 %1, i32 11");
+        assert_eq!(&icmp.to_string(), "%5 = icmp slt i32 %1, 11");
     }
     #[cfg(feature = "llvm-14-or-greater")]
     {
@@ -740,9 +740,9 @@ fn loopbc() {
         );
         assert_eq!(module.type_of(icmp), module.types.bool());
         #[cfg(feature = "llvm-14-or-lower")]
-        assert_eq!(&icmp.to_string(), "%6 = icmp ult i32 %5, i32 10");
+        assert_eq!(&icmp.to_string(), "%6 = icmp ult i32 %5, 10");
         #[cfg(feature = "llvm-15-or-greater")]
-        assert_eq!(&icmp.to_string(), "%5 = icmp ult i32 %4, i32 10");
+        assert_eq!(&icmp.to_string(), "%5 = icmp ult i32 %4, 10");
     }
 
     let condbr: &terminator::CondBr = &bbs[0].term.clone().try_into().expect("Should be a condbr");
@@ -1037,37 +1037,37 @@ fn loopbc() {
     #[cfg(feature = "llvm-9-or-lower")]
     assert_eq!(
         &phi.to_string(),
-        "%11 = phi i64 [ i64 0, %7 ], [ i64 %20, %19 ]"
+        "%11 = phi i64 [ 0, %7 ], [ %20, %19 ]"
     );
     #[cfg(feature = "llvm-10")]
     assert_eq!(
         &phi.to_string(),
-        "%13 = phi i64 [ i64 %19, %12 ], [ i64 1, %7 ]"
+        "%13 = phi i64 [ %19, %12 ], [ 1, %7 ]"
     );
     #[cfg(feature = "llvm-11")]
     assert_eq!(
         &phi.to_string(),
-        "%15 = phi i64 [ i64 %22, %14 ], [ i64 1, %7 ]"
+        "%15 = phi i64 [ %22, %14 ], [ 1, %7 ]"
     );
     #[cfg(any(feature = "llvm-12", feature = "llvm-13"))]
     assert_eq!(
         &phi.to_string(),
-        "%20 = phi i64 [ i64 1, %17 ], [ i64 %34, %19 ]"
+        "%20 = phi i64 [ 1, %17 ], [ %34, %19 ]"
     );
     #[cfg(feature = "llvm-14")]
     assert_eq!(
         &phi.to_string(),
-        "%19 = phi i64 [ i64 1, %16 ], [ i64 %33, %18 ]"
+        "%19 = phi i64 [ 1, %16 ], [ %33, %18 ]"
     );
     #[cfg(all(feature = "llvm-15-or-greater", feature = "llvm-17-or-lower"))]
     assert_eq!(
         &phi.to_string(),
-        "%17 = phi i64 [ i64 1, %14 ], [ i64 %31, %16 ]"
+        "%17 = phi i64 [ 1, %14 ], [ %31, %16 ]"
     );
     #[cfg(feature = "llvm-18-or-greater")]
     assert_eq!(
         &phi.to_string(),
-        "%17 = phi i64 [ i64 1, %14 ], [ i64 %29, %16 ]"
+        "%17 = phi i64 [ 1, %14 ], [ %29, %16 ]"
     );
 
     #[cfg(feature = "llvm-11-or-lower")]
@@ -1159,12 +1159,12 @@ fn loopbc() {
     #[cfg(feature = "llvm-14")]
     assert_eq!(
         &gep.to_string(),
-        "%21 = getelementptr inbounds [10 x i32]* %3, i64 0, i64 %19"
+        "%21 = getelementptr inbounds [10 x i32], [10 x i32]* %3, i64 0, i64 %19"
     );
     #[cfg(feature = "llvm-15-or-greater")]
     assert_eq!(
         &gep.to_string(),
-        "%19 = getelementptr inbounds ptr %3, i64 0, i64 %17"
+        "%19 = getelementptr inbounds [10 x i32], ptr %3, i64 0, i64 %17"
     );
     #[cfg(feature = "llvm-11-or-lower")]
     let store_inst = &bbs[2].instrs[2];
@@ -1459,7 +1459,7 @@ fn switchbc() {
     assert_eq!(switch.default_dest, Name::Number(10));
     assert_eq!(
         &switch.to_string(),
-        "switch i32 %0, label %10 [ i32 0, label %12; i32 1, label %2; i32 13, label %3; i32 26, label %4; i32 33, label %5; i32 142, label %6; i32 1678, label %7; i32 88, label %8; i32 101, label %9; ]",
+        "switch i32 %0, label %10 [\n    i32 0, label %12\n    i32 1, label %2\n    i32 13, label %3\n    i32 26, label %4\n    i32 33, label %5\n    i32 142, label %6\n    i32 1678, label %7\n    i32 88, label %8\n    i32 101, label %9\n  ]",
     );
 
     let phibb = &func
@@ -1469,7 +1469,7 @@ fn switchbc() {
     assert_eq!(phi.incoming_values.len(), 10);
     assert_eq!(
         &phi.to_string(),
-        "%13 = phi i32 [ i32 -1, %10 ], [ i32 -3, %9 ], [ i32 0, %8 ], [ i32 77, %7 ], [ i32 -33, %6 ], [ i32 1, %5 ], [ i32 -5, %4 ], [ i32 -7, %3 ], [ i32 5, %2 ], [ i32 3, %1 ]",
+        "%13 = phi i32 [ -1, %10 ], [ -3, %9 ], [ 0, %8 ], [ 77, %7 ], [ -33, %6 ], [ 1, %5 ], [ -5, %4 ], [ -7, %3 ], [ 5, %2 ], [ 3, %1 ]",
     );
 
     assert_eq!(
@@ -1909,9 +1909,9 @@ fn rustbc() {
     );
     assert_eq!(call.dest, Some(Name::Number(0)));
     #[cfg(feature = "llvm-14-or-lower")]
-    let expected_fmt = "%0 = call @_ZN68_$LT$alloc..vec..Vec$LT$T$GT$$u20$as$u20$core..ops..deref..Deref$GT$5deref17h378128d7d9378466E(%alloc::vec::Vec<isize>* %v)";
+    let expected_fmt = "%0 = call @_ZN68_$LT$alloc..vec..Vec$LT$T$GT$$u20$as$u20$core..ops..deref..Deref$GT$5deref17h378128d7d9378466E(%alloc::vec::Vec<isize>* noalias align 8 dereferenceable(24) %v)";
     #[cfg(feature = "llvm-15-or-greater")]
-    let expected_fmt = "%0 = call @_ZN68_$LT$alloc..vec..Vec$LT$T$GT$$u20$as$u20$core..ops..deref..Deref$GT$5deref17h378128d7d9378466E(ptr %v)";
+    let expected_fmt = "%0 = call { ptr, i64 } @_ZN68_$LT$alloc..vec..Vec$LT$T$GT$$u20$as$u20$core..ops..deref..Deref$GT$5deref17h378128d7d9378466E(ptr noalias align 8 dereferenceable(24) %v)";
     assert_eq!(&call.to_string(), expected_fmt);
 
     // this file was compiled without debuginfo, so nothing should have a debugloc
@@ -1984,9 +1984,9 @@ fn rustbcg() {
     assert_eq!(call_debugloc.filename.as_str(), debug_filename);
     assert!(debugloc.directory.as_ref().expect("directory should exist").ends_with(debug_directory_suffix));
     #[cfg(feature = "llvm-14-or-lower")]
-    let expected_fmt = "%4 = call @_ZN68_$LT$alloc..vec..Vec$LT$T$GT$$u20$as$u20$core..ops..deref..Deref$GT$5deref17h378128d7d9378466E(%alloc::vec::Vec<isize>* %3) (with debugloc)";
+    let expected_fmt = "%4 = call @_ZN68_$LT$alloc..vec..Vec$LT$T$GT$$u20$as$u20$core..ops..deref..Deref$GT$5deref17h378128d7d9378466E(%alloc::vec::Vec<isize>* noalias align 8 dereferenceable(24) %3) (with debugloc)";
     #[cfg(feature = "llvm-15-or-greater")]
-    let expected_fmt = "%4 = call @_ZN68_$LT$alloc..vec..Vec$LT$T$GT$$u20$as$u20$core..ops..deref..Deref$GT$5deref17h378128d7d9378466E(ptr %3) (with debugloc)";
+    let expected_fmt = "%4 = call { ptr, i64 } @_ZN68_$LT$alloc..vec..Vec$LT$T$GT$$u20$as$u20$core..ops..deref..Deref$GT$5deref17h378128d7d9378466E(ptr noalias align 8 dereferenceable(24) %3) (with debugloc)";
     assert_eq!(&startbb.instrs[EXPECTED_CALL_INSTRUCTION_INDEX].to_string(), expected_fmt);
 }
 
@@ -2157,9 +2157,15 @@ fn simple_linked_list_g() {
         assert_eq!(debugloc.col, Some(28));
         assert_eq!(debugloc.filename.as_str(), debug_filename);
         assert!(debugloc.directory.as_ref().expect("directory should exist").ends_with(debug_directory_suffix));
+        #[cfg(feature = "llvm-14-or-lower")]
         assert_eq!(
             &func.basic_blocks[0].instrs[7].to_string(),
             "call @llvm.dbg.declare(<metadata>, <metadata>, <metadata>) (with debugloc)",
+        );
+        #[cfg(feature = "llvm-15-or-greater")]
+        assert_eq!(
+            &func.basic_blocks[0].instrs[7].to_string(),
+            "call void @llvm.dbg.declare(<metadata>, <metadata>, <metadata>) (with debugloc)",
         );
     }
 
@@ -2173,11 +2179,14 @@ fn simple_linked_list_g() {
     assert_eq!(debugloc.filename.as_str(), debug_filename);
     assert!(debugloc.directory.as_ref().expect("directory should exist").ends_with(debug_directory_suffix));
 
-    #[cfg(feature = "llvm-14-or-lower")]
+    #[cfg(feature = "llvm-13-or-lower")]
     let expected_fmt =
         "%8 = getelementptr inbounds %struct.SimpleLinkedList* %3, i32 0, i32 0 (with debugloc)";
+    #[cfg(feature = "llvm-14")]
+    let expected_fmt =
+        "%8 = getelementptr inbounds %struct.SimpleLinkedList, %struct.SimpleLinkedList* %3, i32 0, i32 0 (with debugloc)";
     #[cfg(all(feature = "llvm-15-or-greater", feature = "llvm-18-or-lower"))]
-    let expected_fmt = "%8 = getelementptr inbounds ptr %3, i32 0, i32 0 (with debugloc)";
+    let expected_fmt = "%8 = getelementptr inbounds %struct.SimpleLinkedList, ptr %3, i32 0, i32 0 (with debugloc)";
     #[cfg(feature = "llvm-19-or-greater")]
     let expected_fmt = "store i32 %9, ptr %8, align 8 (with debugloc)";
 

--- a/tests/display_tests.rs
+++ b/tests/display_tests.rs
@@ -1,0 +1,108 @@
+use llvm_ir::Module;
+use std::path::{Path, PathBuf};
+
+fn init_logging() {
+    let _ = env_logger::builder().is_test(true).try_init();
+}
+
+const BC_DIR: &str = "tests/basic_bc/";
+
+fn llvm_bc_dir() -> PathBuf {
+    if cfg!(feature = "llvm-9") {
+        Path::new(BC_DIR).join("llvm9")
+    } else if cfg!(feature = "llvm-10") {
+        Path::new(BC_DIR).join("llvm10")
+    } else if cfg!(feature = "llvm-11") {
+        Path::new(BC_DIR).join("llvm11")
+    } else if cfg!(feature = "llvm-12") {
+        Path::new(BC_DIR).join("llvm12")
+    } else if cfg!(feature = "llvm-13") {
+        Path::new(BC_DIR).join("llvm13")
+    } else if cfg!(feature = "llvm-14") {
+        Path::new(BC_DIR).join("llvm14")
+    } else if cfg!(feature = "llvm-15") {
+        Path::new(BC_DIR).join("llvm15")
+    } else if cfg!(feature = "llvm-16") {
+        Path::new(BC_DIR).join("llvm16")
+    } else if cfg!(feature = "llvm-17") {
+        Path::new(BC_DIR).join("llvm17")
+    } else if cfg!(feature = "llvm-18") {
+        Path::new(BC_DIR).join("llvm18")
+    } else if cfg!(feature = "llvm-19") {
+        Path::new(BC_DIR).join("llvm19")
+    } else {
+        unimplemented!("new llvm version?")
+    }
+}
+
+/// Parse a `.bc` file, display it as `.ll` text, then re-parse the generated
+/// text with LLVM to verify it produces valid IR.
+///
+/// Roundtrip is only supported for LLVM 15+ (opaque pointers). For LLVM 14
+/// and below, some existing instruction Display impls intentionally differ
+/// from valid LLVM IR syntax (e.g., Load omits the destination type).
+#[cfg(feature = "llvm-15-or-greater")]
+fn roundtrip_bc(filename: &str) {
+    init_logging();
+    let path = llvm_bc_dir().join(filename);
+    let module = Module::from_bc_path(&path).expect("Failed to parse bc");
+    let ll_text = module.to_string();
+
+    // Re-parse the generated text through LLVM's IR parser to ensure validity
+    let reparsed = Module::from_ir_str(&ll_text);
+    match reparsed {
+        Ok(_) => {},
+        Err(e) => {
+            // Print the generated IR for debugging
+            eprintln!("Generated IR:\n{}", ll_text);
+            panic!(
+                "Roundtrip failed for {}: generated IR did not re-parse: {}",
+                filename, e
+            );
+        },
+    }
+}
+
+#[test]
+#[cfg(feature = "llvm-15-or-greater")]
+fn display_hello() {
+    roundtrip_bc("hello.bc");
+}
+
+#[test]
+#[cfg(feature = "llvm-15-or-greater")]
+fn display_loop() {
+    roundtrip_bc("loop.bc");
+}
+
+#[test]
+#[cfg(feature = "llvm-15-or-greater")]
+fn display_switch() {
+    roundtrip_bc("switch.bc");
+}
+
+#[test]
+#[cfg(feature = "llvm-15-or-greater")]
+fn display_variables() {
+    roundtrip_bc("variables.bc");
+}
+
+#[test]
+#[cfg(feature = "llvm-15-or-greater")]
+fn display_linkedlist() {
+    roundtrip_bc("linkedlist.bc");
+}
+
+#[test]
+fn display_module_to_string() {
+    init_logging();
+    let path = llvm_bc_dir().join("hello.bc");
+    let module = Module::from_bc_path(&path).expect("Failed to parse bc");
+    let text = module.to_string();
+
+    // Basic structural checks
+    assert!(text.contains("source_filename"));
+    assert!(text.contains("target datalayout"));
+    assert!(text.contains("define"));
+    assert!(text.contains("ret i32"));
+}

--- a/tests/llvm_17_tests.rs
+++ b/tests/llvm_17_tests.rs
@@ -44,7 +44,7 @@ fn nuw_nsw_exact() {
         .expect("Expected an add");
     assert_eq!(add.nuw, false);
     assert_eq!(add.nsw, false);
-    assert_eq!(&format!("{add}"), "%1 = add i8 %op1, i8 %op2");
+    assert_eq!(&format!("{add}"), "%1 = add i8 %op1, %op2");
     let add: &instruction::Add = &bb
         .instrs[1]
         .clone()
@@ -52,7 +52,7 @@ fn nuw_nsw_exact() {
         .expect("Expected an add");
     assert_eq!(add.nuw, true);
     assert_eq!(add.nsw, false);
-    assert_eq!(&format!("{add}"), "%2 = add nuw i8 %op1, i8 %op2");
+    assert_eq!(&format!("{add}"), "%2 = add nuw i8 %op1, %op2");
     let add: &instruction::Add = &bb
         .instrs[2]
         .clone()
@@ -60,7 +60,7 @@ fn nuw_nsw_exact() {
         .expect("Expected an add");
     assert_eq!(add.nuw, false);
     assert_eq!(add.nsw, true);
-    assert_eq!(&format!("{add}"), "%3 = add nsw i8 %op1, i8 %op2");
+    assert_eq!(&format!("{add}"), "%3 = add nsw i8 %op1, %op2");
     let add: &instruction::Add = &bb
         .instrs[3]
         .clone()
@@ -68,7 +68,7 @@ fn nuw_nsw_exact() {
         .expect("Expected an add");
     assert_eq!(add.nuw, true);
     assert_eq!(add.nsw, true);
-    assert_eq!(&format!("{add}"), "%4 = add nuw nsw i8 %op1, i8 %op2");
+    assert_eq!(&format!("{add}"), "%4 = add nuw nsw i8 %op1, %op2");
 
     let sub: &instruction::Sub = &bb
         .instrs[4]
@@ -77,7 +77,7 @@ fn nuw_nsw_exact() {
         .expect("Expected a sub");
     assert_eq!(sub.nuw, false);
     assert_eq!(sub.nsw, false);
-    assert_eq!(&format!("{sub}"), "%5 = sub i8 %op1, i8 %op2");
+    assert_eq!(&format!("{sub}"), "%5 = sub i8 %op1, %op2");
     let sub: &instruction::Sub = &bb
         .instrs[5]
         .clone()
@@ -85,7 +85,7 @@ fn nuw_nsw_exact() {
         .expect("Expected a sub");
     assert_eq!(sub.nuw, true);
     assert_eq!(sub.nsw, false);
-    assert_eq!(&format!("{sub}"), "%6 = sub nuw i8 %op1, i8 %op2");
+    assert_eq!(&format!("{sub}"), "%6 = sub nuw i8 %op1, %op2");
     let sub: &instruction::Sub = &bb
         .instrs[6]
         .clone()
@@ -93,7 +93,7 @@ fn nuw_nsw_exact() {
         .expect("Expected a sub");
     assert_eq!(sub.nuw, false);
     assert_eq!(sub.nsw, true);
-    assert_eq!(&format!("{sub}"), "%7 = sub nsw i8 %op1, i8 %op2");
+    assert_eq!(&format!("{sub}"), "%7 = sub nsw i8 %op1, %op2");
     let sub: &instruction::Sub = &bb
         .instrs[7]
         .clone()
@@ -101,7 +101,7 @@ fn nuw_nsw_exact() {
         .expect("Expected a sub");
     assert_eq!(sub.nuw, true);
     assert_eq!(sub.nsw, true);
-    assert_eq!(&format!("{sub}"), "%8 = sub nuw nsw i8 %op1, i8 %op2");
+    assert_eq!(&format!("{sub}"), "%8 = sub nuw nsw i8 %op1, %op2");
 
     let mul: &instruction::Mul = &bb
         .instrs[8]
@@ -110,7 +110,7 @@ fn nuw_nsw_exact() {
         .expect("Expected a mul");
     assert_eq!(mul.nuw, false);
     assert_eq!(mul.nsw, false);
-    assert_eq!(&format!("{mul}"), "%9 = mul i8 %op1, i8 %op2");
+    assert_eq!(&format!("{mul}"), "%9 = mul i8 %op1, %op2");
     let mul: &instruction::Mul = &bb
         .instrs[9]
         .clone()
@@ -118,7 +118,7 @@ fn nuw_nsw_exact() {
         .expect("Expected a mul");
     assert_eq!(mul.nuw, true);
     assert_eq!(mul.nsw, false);
-    assert_eq!(&format!("{mul}"), "%10 = mul nuw i8 %op1, i8 %op2");
+    assert_eq!(&format!("{mul}"), "%10 = mul nuw i8 %op1, %op2");
     let mul: &instruction::Mul = &bb
         .instrs[10]
         .clone()
@@ -126,7 +126,7 @@ fn nuw_nsw_exact() {
         .expect("Expected a mul");
     assert_eq!(mul.nuw, false);
     assert_eq!(mul.nsw, true);
-    assert_eq!(&format!("{mul}"), "%11 = mul nsw i8 %op1, i8 %op2");
+    assert_eq!(&format!("{mul}"), "%11 = mul nsw i8 %op1, %op2");
     let mul: &instruction::Mul = &bb
         .instrs[11]
         .clone()
@@ -134,7 +134,7 @@ fn nuw_nsw_exact() {
         .expect("Expected a mul");
     assert_eq!(mul.nuw, true);
     assert_eq!(mul.nsw, true);
-    assert_eq!(&format!("{mul}"), "%12 = mul nuw nsw i8 %op1, i8 %op2");
+    assert_eq!(&format!("{mul}"), "%12 = mul nuw nsw i8 %op1, %op2");
 
     let udiv: &instruction::UDiv = &bb
         .instrs[12]
@@ -142,14 +142,14 @@ fn nuw_nsw_exact() {
         .try_into()
         .expect("Expected a udiv");
     assert_eq!(udiv.exact, false);
-    assert_eq!(&format!("{udiv}"), "%13 = udiv i8 %op1, i8 %op2");
+    assert_eq!(&format!("{udiv}"), "%13 = udiv i8 %op1, %op2");
     let udiv: &instruction::UDiv = &bb
         .instrs[13]
         .clone()
         .try_into()
         .expect("Expected a udiv");
     assert_eq!(udiv.exact, true);
-    assert_eq!(&format!("{udiv}"), "%14 = udiv exact i8 %op1, i8 %op2");
+    assert_eq!(&format!("{udiv}"), "%14 = udiv exact i8 %op1, %op2");
 
     let sdiv: &instruction::SDiv = &bb
         .instrs[14]
@@ -157,12 +157,12 @@ fn nuw_nsw_exact() {
         .try_into()
         .expect("Expected an sdiv");
     assert_eq!(sdiv.exact, false);
-    assert_eq!(&format!("{sdiv}"), "%15 = sdiv i8 %op1, i8 %op2");
+    assert_eq!(&format!("{sdiv}"), "%15 = sdiv i8 %op1, %op2");
     let sdiv: &instruction::SDiv = &bb
         .instrs[15]
         .clone()
         .try_into()
         .expect("Expected an sdiv");
     assert_eq!(sdiv.exact, true);
-    assert_eq!(&format!("{sdiv}"), "%16 = sdiv exact i8 %op1, i8 %op2");
+    assert_eq!(&format!("{sdiv}"), "%16 = sdiv exact i8 %op1, %op2");
 }

--- a/tests/llvm_8_tests.rs
+++ b/tests/llvm_8_tests.rs
@@ -285,7 +285,7 @@ fn DILocation_implicit_code_extra_checks() {
     #[cfg(feature = "llvm-14-or-lower")]
     let expected_fmt = "%0 = invoke @_ZN1A3fooEi(%struct.A* %a, i32 0) to label %invoke.cont unwind label %lpad (with debugloc)";
     #[cfg(feature = "llvm-15-or-greater")]
-    let expected_fmt = "%0 = invoke @_ZN1A3fooEi(ptr %a, i32 0) to label %invoke.cont unwind label %lpad (with debugloc)";
+    let expected_fmt = "%0 = invoke void @_ZN1A3fooEi(ptr %a, i32 0) to label %invoke.cont unwind label %lpad (with debugloc)";
     assert_eq!(&format!("{}", invoke), expected_fmt);
 
     // For the rest of the function, our numbered variables are one-off the


### PR DESCRIPTION
Addresses issue #46 

Add Display impls for Module, Function, FunctionDeclaration, BasicBlock, GlobalVariable, GlobalAlias, GlobalIFunc, Parameter, and all supporting enums (Linkage, Visibility, CallingConvention, FunctionAttribute, etc.). Module::to_string() now produces valid .ll files that LLVM can re-parse.

Also fix existing Display impls for instructions, terminators, and operands to emit correct LLVM IR syntax (binary op second operand without type, phi values without types in brackets, call/invoke with return type, GEP with source element type, switch with newlines).